### PR TITLE
Handle FREE_IT flag when generating function SQL.

### DIFF
--- a/src/metadata/function.cpp
+++ b/src/metadata/function.cpp
@@ -183,6 +183,9 @@ void Function::loadProperties()
                     paramListM += ", ";
                 paramListM += datatype + mechanismDDL[mechIndex];
             }
+            if (mechanism < 0){
+              retstrM += wxString(" ") + SqlTokenizer::getKeyword(kwFREE_IT);
+            }
         }
         else
         {


### PR DESCRIPTION
Add FREE_IT flag to external function return definition when needed.
Fixes incorrect external function definition in DDL pages.