### PR TITLE
Update configure and build instructions for Mac OS

### DIFF
--- a/BUILD.txt
+++ b/BUILD.txt
@@ -182,26 +182,40 @@ question there.
 -- Mac OS X - Autoconf Build Instructions --
 --------------------------------------------
 
+Before compiling you need to install these packages (easily with brew)
+
+brew install autoconf
+brew install wxwidgets
+brew install boost
+
 To build FlameRobin on Mac OS X 10.5 minimum, open
 a command line, cd into the flamerobin root directory, and execute the
 following commands:
 
-
 cd ..
-mkdir x86_64
-cd x86_64
-../configure --disable-debug --disable-dependency-tracking \
-  CFLAGS="-mmacosx-version-min=10.5 -isysroot /Developer/SDKs/MacOSX10.5u.sdk" \
-  LDFLAGS="-Wl,-syslibroot,/Developer/SDKs/MacOSX10.4u.sdk \
-    -Wl,-macosx_version_min -Wl,10.5" \
-  CXXFLAGS="-mmacosx-version-min=10.5 -isysroot /Developer/SDKs/MacOSX10.5u.sdk" \
-  --with-wx-config=/my/path/to/wx-config_for_x86_64_unicode
-make
+mkdir release
+cd release
+../configure --disable-debug --disable-dependency-tracking
+
+After configuration, open created Makefile and fix path for linking Firebird (otherwise you will get error from linker)
+
+Change this line:
+LIBS = -framework Firebird
+to this
+LIBS = /Library/Frameworks/Firebird.framework/Firebird
+
+Save and then compile and install:
+
+make -j4
+make install
+
+Copy missing sys-templates:
+cp -R ../sys-templates FlameRobin.app/Contents/SharedSupport/sys-templates
+
+Now you will have working Flamerobin.app which you should move to /Applications folder.
 
 The resulting bundles differ only in the flamerobin executable, the lipo
 tool can be used to make a Universal Build out of them.
-
-
 
 ----------------------------------------------
 -- Unix - Building wxWidgets with configure --

--- a/BUILD.txt
+++ b/BUILD.txt
@@ -196,21 +196,8 @@ cd ..
 mkdir release
 cd release
 ../configure --disable-debug --disable-dependency-tracking
-
-After configuration, open created Makefile and fix path for linking Firebird (otherwise you will get error from linker)
-
-Change this line:
-LIBS = -framework Firebird
-to this
-LIBS = /Library/Frameworks/Firebird.framework/Firebird
-
-Save and then compile and install:
-
-make -j4
+make
 make install
-
-Copy missing sys-templates:
-cp -R ../sys-templates FlameRobin.app/Contents/SharedSupport/sys-templates
 
 Now you will have working Flamerobin.app which you should move to /Applications folder.
 

--- a/configure
+++ b/configure
@@ -790,7 +790,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -883,7 +882,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -1136,15 +1134,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1282,7 +1271,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1435,7 +1424,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -16476,7 +16464,7 @@ case "${host}" in
             ;;
 
     *-*-darwin* )
-                LIBS="$LIBS -framework Firebird"
+                LIBS="$LIBS /Library/Frameworks/Firebird.Framework/Firebird"
     ;;
 
     * )

--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,7 @@ case "${host}" in
 
     *-*-darwin* )
         dnl Mac OS X uses the Firebird framework
-        LIBS="$LIBS -framework Firebird"
+        LIBS="$LIBS /Library/Frameworks/Firebird.Framework/Firebird"
     ;;
 
     * )


### PR DESCRIPTION
The build instructions for Mac OS are outdated and the article that you have posted from 2016 https://flamerobin.blogspot.com/2016/01/compiling-flamerobin-under-mac-os-x.html which was from me is outdated as well.

This pull request contains steps how to compile Flamerobin on the latest Mac OS version (10.15.4)