### PR TITLE
Add support for SQL statements longer than 64KB

### DIFF
--- a/src/ibpp/statement.cpp
+++ b/src/ibpp/statement.cpp
@@ -90,7 +90,7 @@ void StatementImpl::Prepare(const std::string& sql)
 
 	status.Reset();
 	(*gds.Call()->m_dsql_prepare)(status.Self(), mTransaction->GetHandlePtr(),
-		&mHandle, (short)mSql.length(), const_cast<char*>(mSql.c_str()),
+		&mHandle, 0, const_cast<char*>(mSql.c_str()),
 			short(mDatabase->Dialect()), mOutRow->Self());
 	if (status.Errors())
 	{


### PR DESCRIPTION
This patch allows Firebird to set the statement length, so you can execute SQL statements longer than 64K in Firebird 3.0.