### PR TITLE
Using '%p' formatting for 'parent_window' strings

### DIFF
--- a/src/gui/GUIURIHandlerHelper.cpp
+++ b/src/gui/GUIURIHandlerHelper.cpp
@@ -35,8 +35,9 @@
 wxWindow* GUIURIHandlerHelper::getParentWindow(const URI& uri)
 {
     wxString ms = uri.getParam("parent_window");
-    unsigned long mo;
-    if (!ms.ToULong(&mo))
-        return 0;
-    return (wxWindow*)mo;
+    wxWindow* res;
+    if (!wxSscanf(ms, "%p", &res)) {
+         return NULL;
+    }
+    return res;
 }

--- a/src/gui/GUIURIHandlerHelper.cpp
+++ b/src/gui/GUIURIHandlerHelper.cpp
@@ -35,8 +35,9 @@
 wxWindow* GUIURIHandlerHelper::getParentWindow(const URI& uri)
 {
     wxString ms = uri.getParam("parent_window");
-    unsigned long mo;
-    if (!ms.ToULong(&mo, 16))
-        return 0;
-    return (wxWindow*)mo;
+    wxWindow* res;
+    if (!wxSscanf(ms, "%p", &res)) {
+         return NULL;
+    }
+    return res;
 }

--- a/src/gui/MainFrame.cpp
+++ b/src/gui/MainFrame.cpp
@@ -1341,7 +1341,6 @@ void MainFrame::OnMenuAddColumn(wxCommandEvent& WXUNUSED(event))
         return;
 
     URI uri("fr://add_field");
-
     uri.addParam(wxString::Format("parent_window=%p",this));
     uri.addParam(wxString::Format("object_handle=%lu", t->getHandle()));
     getURIProcessor().handleURI(uri);
@@ -1463,7 +1462,6 @@ void MainFrame::OnMenuObjectProperties(wxCommandEvent& WXUNUSED(event))
             return;
 
         URI uri("fr://edit_field");
-
         uri.addParam(wxString::Format("parent_window=%p", this));
         uri.addParam(wxString::Format("object_handle=%lu", c->getHandle()));
 

--- a/src/gui/MainFrame.cpp
+++ b/src/gui/MainFrame.cpp
@@ -1234,8 +1234,8 @@ void MainFrame::OnMenuSetGeneratorValue(wxCommandEvent& WXUNUSED(event))
         return;
 
     URI uri("fr://edit_generator_value");
-    uri.addParam(wxString::Format("parent_window=%ld", (uintptr_t)this));
-    uri.addParam(wxString::Format("object_handle=%d", g->getHandle()));
+    uri.addParam(wxString::Format("parent_window=%p", this));
+    uri.addParam(wxString::Format("object_handle=%lu", g->getHandle()));
     getURIProcessor().handleURI(uri);
 }
 
@@ -1341,8 +1341,8 @@ void MainFrame::OnMenuAddColumn(wxCommandEvent& WXUNUSED(event))
         return;
 
     URI uri("fr://add_field");
-    uri.addParam(wxString::Format("parent_window=%ld", (uintptr_t)this));
-    uri.addParam(wxString::Format("object_handle=%d", t->getHandle()));
+    uri.addParam(wxString::Format("parent_window=%p",this));
+    uri.addParam(wxString::Format("object_handle=%lu", t->getHandle()));
     getURIProcessor().handleURI(uri);
 }
 
@@ -1462,10 +1462,8 @@ void MainFrame::OnMenuObjectProperties(wxCommandEvent& WXUNUSED(event))
             return;
 
         URI uri("fr://edit_field");
-        uri.addParam(wxString::Format("parent_window=%ld",
-            (uintptr_t)this));
-        uri.addParam(wxString::Format("object_handle=%d",
-            c->getHandle()));
+        uri.addParam(wxString::Format("parent_window=%p", this));
+        uri.addParam(wxString::Format("object_handle=%lu", c->getHandle()));
         getURIProcessor().handleURI(uri);
     }
     else
@@ -1495,8 +1493,8 @@ void MainFrame::OnMenuAlterObject(wxCommandEvent& WXUNUSED(event))
     if (p)
     {
         URI uri("fr://edit_procedure");
-        uri.addParam(wxString::Format("parent_window=%ld", (uintptr_t)this));
-        uri.addParam(wxString::Format("object_handle=%d", p->getHandle()));
+        uri.addParam(wxString::Format("parent_window=%p", this));
+        uri.addParam(wxString::Format("object_handle=%lu", p->getHandle()));
         getURIProcessor().handleURI(uri);
         return;
     }

--- a/src/metadata/MetadataTemplateCmdHandler.cpp
+++ b/src/metadata/MetadataTemplateCmdHandler.cpp
@@ -107,7 +107,7 @@ void MetadataTemplateCmdHandler::handleTemplateCmd(TemplateProcessor *tp,
     // Expands to the current object's unique numeric handle.
     // Used to call FR's commands through URIs.
     else if ((cmdName == "object_handle") && metadataItem)
-        processedText += wxString::Format("%ld", metadataItem->getHandle());
+        processedText += wxString::Format("%lu", metadataItem->getHandle());
 
     // {%object_name%}
     // Expands to the current object's (non quoted) name.


### PR DESCRIPTION
Follow up to PR #80
Also, using correct '%lu' for 'object_handle' items.
Had to use barely documented wxSscanf function for translating back from string.