### PR TITLE
Wrong format in log call

### DIFF
--- a/src/gui/ExecuteSqlFrame.cpp
+++ b/src/gui/ExecuteSqlFrame.cpp
@@ -2389,7 +2389,7 @@ bool ExecuteSqlFrame::execute(wxString sql, const wxString& terminator,
         if (prepareOnly)
             return true;
 
-        log(wxString::Format(_("Parametros: %d"), statementM->ParametersByName().size() ));
+        log(wxString::Format(_("Parametros: %zu"), statementM->ParametersByName().size() ));
         //Define parameters here:
         if (statementM->ParametersByName().size() >0)
         {


### PR DESCRIPTION
size_t type needs '%zu', was failing under 64-bit build