### PR TITLE
max plan size can be 65535

### DIFF
--- a/src/ibpp/statement.cpp
+++ b/src/ibpp/statement.cpp
@@ -244,7 +244,7 @@ void StatementImpl::Plan(std::string& plan)
 		throw LogicExceptionImpl("Statement::Plan", _("Database must be connected."));
 
 	IBS status;
-	RB result(16384);
+	RB result(65535);
 	char itemsReq[] = {isc_info_sql_get_plan};
 
 	(*gds.Call()->m_dsql_sql_info)(status.Self(), &mHandle, 1, itemsReq,


### PR DESCRIPTION
#define MAX_USHORT ((USHORT)0xFFFF)

so we can increase to that value for firebird 3.x
https://github.com/FirebirdSQL/firebird/blob/16773595535af954f6a3f6eee10537043f3b0ffa/src/dsql/dsql.cpp#L2154