### PR TITLE
Reverted changes to StartStyling calls

### DIFF
--- a/flamerobin_flamerobin.vcxproj
+++ b/flamerobin_flamerobin.vcxproj
@@ -70,6 +70,7 @@
     <ProjectName>flamerobin</ProjectName>
     <ProjectGuid>{3C914FEE-C6E8-58AA-B046-6E951FCD6BFC}</ProjectGuid>
     <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DLL Release Static|Win32'" Label="Configuration">

--- a/src/gui/AdvancedSearchFrame.cpp
+++ b/src/gui/AdvancedSearchFrame.cpp
@@ -456,7 +456,7 @@ void AdvancedSearchFrame::OnListCtrlResultsItemSelected(wxListEvent& event)
                 p = sql.find(sfind, p+1);
                 if (p == int(wxString::npos))
                     break;
-                stc_ddl->StartStyling(p);
+                stc_ddl->StartStyling(p, 0);
                 stc_ddl->SetStyling(len, 1+color%2);
             }
         }

--- a/src/gui/EditBlobDialog.cpp
+++ b/src/gui/EditBlobDialog.cpp
@@ -127,12 +127,12 @@ void EditBlobDialogSTC::setIsNull(bool isNull)
     {
         wxStyledTextCtrl::SetText("[null]");
         SelectAll();
-        StartStyling(0);
+        StartStyling(0, 0);
         SetStyling(GetTextLength(), 0x0A);
     }
     else
     {
-        StartStyling(0);
+        StartStyling(0, 0);
         SetStyling(GetTextLength(), 0);
     }
     isNullM = isNull;
@@ -785,7 +785,7 @@ bool EditBlobDialog::loadFromStreamAsBinary(wxInputStream& stream, bool isNull, 
         }
     }
     // Set text styling
-    blob_binary->StartStyling(0);
+    blob_binary->StartStyling(0, 0);
     for (int i = 0; i < blob_binary->GetLineCount(); i++)
         blob_binary->SetStyleBytes(CharsPerLine, &styleBytes[0]);
     progressEnd();

--- a/src/gui/ExecuteSqlFrame.cpp
+++ b/src/gui/ExecuteSqlFrame.cpp
@@ -349,7 +349,7 @@ void SqlEditor::setup()
     }
 
     if (!config().get("sqlEditorSmartHomeKey", true))
-        CmdKeyAssign(wxSTC_KEY_HOME, wxSTC_KEYMOD_NORM, wxSTC_CMD_HOMEDISPLAY);
+        CmdKeyAssign(wxSTC_KEY_HOME, wxSTC_SCMOD_NORM, wxSTC_CMD_HOMEDISPLAY);
 
     centerCaret(false);
 }

--- a/src/gui/ExecuteSqlFrame.cpp
+++ b/src/gui/ExecuteSqlFrame.cpp
@@ -2925,7 +2925,7 @@ void ExecuteSqlFrame::log(wxString s, TextType type)
     if (type == ttSql)
         style = 2;
 
-    styled_text_ctrl_stats->StartStyling(startpos);
+    styled_text_ctrl_stats->StartStyling(startpos, 0);
     styled_text_ctrl_stats->SetStyling(endpos-startpos-1, style);
 }
 

--- a/src/gui/StatementHistoryDialog.cpp
+++ b/src/gui/StatementHistoryDialog.cpp
@@ -190,7 +190,7 @@ void StatementHistoryDialog::OnListBoxSelect(wxCommandEvent& WXUNUSED(event))
         p = sql.find(searchString, p+1);
         if (p == int(wxString::npos))
             break;
-        textctrl_statement->StartStyling(p);
+        textctrl_statement->StartStyling(p, 0);
         textctrl_statement->SetStyling(searchString.Length(), 1);
     }
 }

--- a/src/gui/controls/LogTextControl.cpp
+++ b/src/gui/controls/LogTextControl.cpp
@@ -56,7 +56,7 @@ void LogTextControl::addStyledText(const wxString& message, LogStyle style)
     bool atEnd = lenBefore == GetCurrentPos();
     AppendText(message);
     int len = GetLength();
-    StartStyling(lenBefore);
+    StartStyling(lenBefore, 0);
     SetStyling(len - lenBefore - 1, int(style));
     if (atEnd)
         GotoPos(len);


### PR DESCRIPTION
Broke compatibility with current release wxWidgets 3.0 (stable).
Revisit when wx3.2 (stable) is released and we can cleanly fix this, for now we can live with the warnings with wx3.1 (development) builds