### PR TITLE
Bool functions exit without returning value

### DIFF
--- a/src/gui/InsertParametersDialog.cpp
+++ b/src/gui/InsertParametersDialog.cpp
@@ -604,7 +604,7 @@ void InsertParametersDialog::OnCancelButtonClick(wxCommandEvent& WXUNUSED(event)
 {
     Close();
 }
-bool InsertParametersDialog::parseDate(int row, const wxString& source)
+void InsertParametersDialog::parseDate(int row, const wxString& source)
 {
     IBPP::Date idt;
     idt.Today();
@@ -629,9 +629,8 @@ bool InsertParametersDialog::parseDate(int row, const wxString& source)
         idt.SetDate(y, m, d);
     }
     statementM->Set(row+1, idt);
-
 }
-bool InsertParametersDialog::parseTime(int row, const wxString& source)
+void InsertParametersDialog::parseTime(int row, const wxString& source)
 {
     IBPP::Time itm;
     itm.Now();
@@ -650,7 +649,7 @@ bool InsertParametersDialog::parseTime(int row, const wxString& source)
     statementM->Set(row+1, itm);
 }
 
-bool InsertParametersDialog::parseTimeStamp(int row, const wxString& source)
+void InsertParametersDialog::parseTimeStamp(int row, const wxString& source)
 {
 
     IBPP::Timestamp its;

--- a/src/gui/InsertParametersDialog.h
+++ b/src/gui/InsertParametersDialog.h
@@ -97,9 +97,9 @@ protected:
     virtual bool getConfigStoresWidth() const;
     virtual bool getConfigStoresHeight() const;
 
-    bool parseDate(int row, const wxString& source);
-    bool parseTime(int row, const wxString& source);
-    bool parseTimeStamp(int row, const wxString& source);
+    void parseDate(int row, const wxString& source);
+    void parseTime(int row, const wxString& source);
+    void parseTimeStamp(int row, const wxString& source);
 
     DECLARE_EVENT_TABLE()
 };


### PR DESCRIPTION
These functions signal failure via exceptions, so swapped them to plain void