### PR TITLE
Force layout update via setProgressMessage

### DIFF
--- a/src/frutils.cpp
+++ b/src/frutils.cpp
@@ -168,7 +168,8 @@ bool connectDatabase(Database* db, wxWindow* parent,
     else
     {
         ProgressDialog pd(parent, caption, 1);
-        db->connect(pass, &pd);;
+        pd.setProgressMessage(caption);
+        db->connect(pass, &pd);
     }
     return true;
 }


### PR DESCRIPTION
Ticket #65 
A guess, but setProgressMessage calls private member doUpdate which may force the dialog to do the right thing