### PR TITLE
Removed use of old auto_ptr class

### DIFF
--- a/src/gui/BackupFrame.cpp
+++ b/src/gui/BackupFrame.cpp
@@ -398,11 +398,10 @@ void BackupFrame::OnStartButtonClick(wxCommandEvent& WXUNUSED(event))
     if (checkbox_extern->IsChecked())
         flags |= (int)IBPP::brConvertExtTables;
 
-    std::auto_ptr<wxThread> thread(new BackupThread(this,
+    startThread(std::make_unique<BackupThread>(this,
         server->getConnectionString(), username, password,
         database->getPath(), text_ctrl_filename->GetValue(),
         (IBPP::BRF)flags));
-    startThread(thread);
     updateControls();
 }
 

--- a/src/gui/BackupRestoreBaseFrame.cpp
+++ b/src/gui/BackupRestoreBaseFrame.cpp
@@ -152,7 +152,7 @@ void BackupRestoreBaseFrame::subjectRemoved(Subject* subject)
         Close();
 }
 
-bool BackupRestoreBaseFrame::startThread(std::auto_ptr<wxThread> thread)
+bool BackupRestoreBaseFrame::startThread(std::unique_ptr<wxThread> thread)
 {
     wxASSERT(threadM == 0);
     if (wxTHREAD_NO_ERROR != thread->Create())

--- a/src/gui/BackupRestoreBaseFrame.h
+++ b/src/gui/BackupRestoreBaseFrame.h
@@ -68,7 +68,7 @@ protected:
     virtual const wxString getStorageName() const;
     // set threadM if thread was successfully created and started,
     // otherwise delete the thread
-    bool startThread(std::auto_ptr<wxThread> thread);
+    bool startThread(std::unique_ptr<wxThread> thread);
     bool getThreadRunning() const;
 
     void threadOutputMsg(const wxString msg, MsgKind kind);

--- a/src/gui/RestoreFrame.cpp
+++ b/src/gui/RestoreFrame.cpp
@@ -441,11 +441,9 @@ void RestoreFrame::OnStartButtonClick(wxCommandEvent& WXUNUSED(event))
     if (!choice_pagesize->GetStringSelection().ToULong(&pagesize))
         pagesize = 0;
 
-    std::auto_ptr<wxThread> thread(new RestoreThread(this,
+    startThread(std::make_unique<RestoreThread>(this,
         server->getConnectionString(), username, password,
         text_ctrl_filename->GetValue(), database->getPath(), pagesize,
         (IBPP::BRF)flags));
-    startThread(thread);
     updateControls();
 }
-

--- a/src/metadata/database.cpp
+++ b/src/metadata/database.cpp
@@ -313,7 +313,7 @@ bool DatabaseAuthenticationMode::getUseEncryptedPassword() const
 // Database class
 Database::Database()
     : MetadataItem(ntDatabase), metadataLoaderM(0), connectedM(false),
-        connectionCredentialsM(0), charsetConverterM(0), dialectM(3), idM(0)
+        connectionCredentialsM(0), dialectM(3), idM(0)
 {
 }
 

--- a/src/metadata/database.h
+++ b/src/metadata/database.h
@@ -160,7 +160,7 @@ private:
     Credentials* connectionCredentialsM;
     DatabaseAuthenticationMode authenticationModeM;
 
-    std::auto_ptr<wxMBConv> charsetConverterM;
+    std::unique_ptr<wxMBConv> charsetConverterM;
     void createCharsetConverter();
 
     DatabaseInfo databaseInfoM;


### PR DESCRIPTION
As of C++17 std::auto_ptr is removed.
Replaced with std::unique_ptr