### PR TITLE
Syntactic fixes to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@ FlameRobin
 FlameRobin is a software package for administration of Firebird DBMS. It is
 developed by:
 
-Milan Babuskov
-Nando Dessena
-Michael Hieke
-Gregory Sapunkov
-Bart Bakker
-Marius Popa
+* Milan Babuskov
+* Nando Dessena
+* Michael Hieke
+* Gregory Sapunkov
+* Bart Bakker
+* Marius Popa
 
 
 The following people also made a significant non-coding contributions:
 
-Alex Stanciu
-Barbara Del Vecchio
+* Alex Stanciu
+* Barbara Del Vecchio
 
 License
 ---------------------------


### PR DESCRIPTION
made proper MD lists of it, an alternative was to insert commas between the names, but this seemed the intended option to me