### PR TITLE
Implement time zone support for firebird 4.

### DIFF
--- a/conf-defs/fr_settings.confdef
+++ b/conf-defs/fr_settings.confdef
@@ -346,7 +346,7 @@
             <expand>1</expand>
         </setting>
         <setting type="radiobox">
-            <caption>Time an timstamp fields with time zone</caption>
+            <caption>Time an timestamp fields with time zone</caption>
             <key>ShowTimezoneInfo</key>
             <default>2</default>
             <option>

--- a/conf-defs/fr_settings.confdef
+++ b/conf-defs/fr_settings.confdef
@@ -345,6 +345,20 @@
             <aligngroup>1</aligngroup>
             <expand>1</expand>
         </setting>
+        <setting type="radiobox">
+            <caption>Time an timstamp fields with time zone</caption>
+            <key>ShowTimezoneInfo</key>
+            <default>2</default>
+            <option>
+                <caption>Don't show time zone info.</caption>
+            </option>
+            <option>
+                <caption>Append time zone id.</caption>
+            </option>
+            <option>
+                <caption>Append time zone name.</caption>
+            </option>
+        </setting>
         <setting type="font">
             <caption>Grid header font:</caption>
             <key>DataGridHeaderFont</key>

--- a/src/gui/DataGeneratorFrame.cpp
+++ b/src/gui/DataGeneratorFrame.cpp
@@ -1172,7 +1172,7 @@ void setFromFile(IBPP::Statement st, int param,
         }
         case IBPP::sdTime:
             str2time(selected, mytime);
-            st->Set(param, IBPP::Time(mytime));
+            st->Set(param, IBPP::Time(IBPP::Time::tmNone, mytime, IBPP::Time::TZ_NONE));
             break;
         case IBPP::sdDate:
             str2date(selected, mydate);
@@ -1185,7 +1185,7 @@ void setFromFile(IBPP::Statement st, int param,
             int y, mo, d, h, mi, s, t;
             IBPP::dtoi(mydate, &y, &mo, &d);
             IBPP::ttoi(mytime, &h, &mi, &s, &t);
-            st->Set(param, IBPP::Timestamp(y, mo, d, h, mi, s, t));
+            st->Set(param, IBPP::Timestamp(y, mo, d, IBPP::Time::tmNone, h, mi, s, t, IBPP::Time::TZ_NONE));
             break;
         }
         case IBPP::sdBlob:
@@ -1445,13 +1445,13 @@ void setDatetime(IBPP::Statement st, int param, GeneratorSettings* gs,
     if (dt == IBPP::sdDate)
         st->Set(param, IBPP::Date(myDate));
     if (dt == IBPP::sdTime)
-        st->Set(param, IBPP::Time(myTime));
+        st->Set(param, IBPP::Time(IBPP::Time::tmNone, myTime, IBPP::Time::TZ_NONE));
     if (dt == IBPP::sdTimestamp)
     {
         int y, mo, d, h, mi, s, t;
         IBPP::dtoi(myDate, &y, &mo, &d);
         IBPP::ttoi(myTime, &h, &mi, &s, &t);
-        st->Set(param, IBPP::Timestamp(y, mo, d, h, mi, s, t));
+        st->Set(param, IBPP::Timestamp(y, mo, d, IBPP::Time::tmNone, h, mi, s, t, IBPP::Time::TZ_NONE));
     }
 }
 

--- a/src/gui/ExecuteSqlFrame.cpp
+++ b/src/gui/ExecuteSqlFrame.cpp
@@ -2186,6 +2186,8 @@ wxString IBPPtype2string(Database *db, IBPP::SDT t, int subtype, int size,
         case IBPP::sdLargeint:  return "BIGINT";
         case IBPP::sdFloat:     return "FLOAT";
         case IBPP::sdDouble:    return "DOUBLE PRECISION";
+        case IBPP::sdTimeTz:    return "TIME WITH TIMEZONE";
+        case IBPP::sdTimestampTz: return "TIMESTAMP WITH TIMEZONE";
         default:                return "UNKNOWN";
     }
 }

--- a/src/gui/InsertDialog.cpp
+++ b/src/gui/InsertDialog.cpp
@@ -359,7 +359,7 @@ void InsertDialog::storeValues()
         it != columnsM.end(); ++it)
     {
         InsertOption sel = getInsertOption(gridM, (*it).row);
-        wxString previous = (*it).columnDef->getAsString(bufferM);
+        wxString previous = (*it).columnDef->getAsString(bufferM, databaseM);
         wxString value = gridM->GetCellValue((*it).row, 3);
         try
         {
@@ -393,7 +393,7 @@ void InsertDialog::storeValues()
                 case ioRegular:
                     (*it).columnDef->setFromString(bufferM, value);
                     gridM->SetCellValue((*it).row, 3,
-                        (*it).columnDef->getAsString(bufferM));
+                        (*it).columnDef->getAsString(bufferM, databaseM));
                     // there is no break; here deliberately!
                 case ioFile:
                     bufferM->setFieldNull((*it).index, false);
@@ -474,12 +474,12 @@ void InsertDialog::preloadSpecialColumns()
         bufferM->setFieldNA((*it).index, false);
         bufferM->setFieldNull((*it).index, st1->IsNull(col));
         if (!st1->IsNull(col))
-            (*it).columnDef->setValue(bufferM, col, st1, wxConvCurrent);
+            (*it).columnDef->setValue(bufferM, col, st1, wxConvCurrent, databaseM);
         ++col;
         if (sel != ioGenerator)  // what follows is only for generators
             continue;
         gridM->SetCellValue((*it).row, 3,
-            (*it).columnDef->getAsString(bufferM));
+            (*it).columnDef->getAsString(bufferM, databaseM));
         gridM->SetCellValue((*it).row, 2,
             insertOptionStrings[ioRegular]);  // treat as regular value
         updateControls((*it).row);
@@ -662,7 +662,7 @@ void InsertDialog::OnGridCellChange(wxGridEvent& event)
             throw;
         }
         gridM->SetCellValue(row, 3,
-            columnsM[row].columnDef->getAsString(bufferM));
+            columnsM[row].columnDef->getAsString(bufferM, databaseM));
         gridM->SetCellValue(row, 2, insertOptionStrings[ioRegular]);
         updateControls(row);
         bufferM->setFieldNull(columnsM[row].index, false);

--- a/src/gui/InsertParametersDialog.cpp
+++ b/src/gui/InsertParametersDialog.cpp
@@ -434,7 +434,7 @@ void InsertParametersDialog::storeValues()
         it != columnsM.end(); ++it)
     {
         InsertParametersOption sel = getInsertParametersOption(gridM, (*it).row);
-        wxString previous = (*it).columnDef->getAsString(bufferM);
+        wxString previous = (*it).columnDef->getAsString(bufferM, databaseM);
         wxString value = gridM->GetCellValue((*it).row, 3);
         try
         {
@@ -468,7 +468,7 @@ void InsertParametersDialog::storeValues()
                 case ioRegular:
                     (*it).columnDef->setFromString(bufferM, value);
                     gridM->SetCellValue((*it).row, 3,
-                        (*it).columnDef->getAsString(bufferM));
+                        (*it).columnDef->getAsString(bufferM, databaseM));
                     // there is no break; here deliberately!
                 case ioFile:
                     bufferM->setFieldNull((*it).index, false);
@@ -551,12 +551,12 @@ void InsertParametersDialog::preloadSpecialColumns()
         bufferM->setFieldNA((*it).index, false);
         bufferM->setFieldNull((*it).index, st1->IsNull(col));
         if (!st1->IsNull(col))
-            (*it).columnDef->setValue(bufferM, col, st1, wxConvCurrent);
+            (*it).columnDef->setValue(bufferM, col, st1, wxConvCurrent, databaseM);
         ++col;
         //if (sel != ioGenerator)  // what follows is only for generators
             continue;
         gridM->SetCellValue((*it).row, 3,
-            (*it).columnDef->getAsString(bufferM));
+            (*it).columnDef->getAsString(bufferM, databaseM));
         gridM->SetCellValue((*it).row, 2,
             insertParametersOptionStrings[ioRegular]);  // treat as regular value
         updateControls((*it).row);
@@ -644,7 +644,7 @@ void InsertParametersDialog::parseTime(int row, const wxString& source)
         int hr = 0, mn = 0, sc = 0, ms = 0;
         if (!GridCellFormats::get().parseTime(it, temp.end(), hr, mn, sc, ms))
             throw FRError(_("Cannot parse time"));
-        itm.SetTime(hr, mn, sc, 10 * ms);
+        itm.SetTime(IBPP::Time::tmNone, hr, mn, sc, 10 * ms, IBPP::Time::TZ_NONE);
     }
     statementM->Set(row+1, itm);
 }
@@ -679,7 +679,7 @@ void InsertParametersDialog::parseTimeStamp(int row, const wxString& source)
             throw FRError(_("Cannot parse timestamp"));
         }
         its.SetDate(y, m, d);
-        its.SetTime(hr, mn, sc, 10 * ms);
+        its.SetTime(IBPP::Time::tmNone, hr, mn, sc, 10 * ms, IBPP::Time::TZ_NONE);
     }
 
     // all done, set the value

--- a/src/gui/controls/DataGridRowBuffer.cpp
+++ b/src/gui/controls/DataGridRowBuffer.cpp
@@ -105,6 +105,14 @@ bool DataGridRowBuffer::getValue(unsigned offset, int64_t& value)
     return true;
 }
 
+bool DataGridRowBuffer::getValue(unsigned offset, uint16_t& value)
+{
+    if (offset + sizeof(uint16_t) > dataM.size())
+        return false;
+    value = *((uint16_t*)&dataM[offset]);
+    return true;
+}
+
 bool DataGridRowBuffer::getValue(unsigned offset, IBPP::DBKey& value,
     unsigned size)
 {

--- a/src/gui/controls/DataGridRowBuffer.h
+++ b/src/gui/controls/DataGridRowBuffer.h
@@ -66,6 +66,7 @@ public:
     bool getValue(unsigned offset, float& value);
     bool getValue(unsigned offset, int& value);
     bool getValue(unsigned offset, int64_t& value);
+    bool getValue(unsigned offset, uint16_t& value);
     bool getValue(unsigned offset, IBPP::DBKey& value, unsigned size);
     bool isFieldNull(unsigned num);
     void setFieldNull(unsigned num, bool isNull);

--- a/src/gui/controls/DataGridRows.h
+++ b/src/gui/controls/DataGridRows.h
@@ -42,6 +42,18 @@ class wxMBConv;
 class GridCellFormats: public ConfigCache
 {
 private:
+    enum ShowTimezoneInfoType
+	{
+        // ** Keep in sync with radiogroup control **
+        // append no timezone info
+        tzNone = 0,
+        // append timezone raw value (id)
+        tzRawId   = 1,
+        // append timezone name
+        tzName = 2
+	};
+
+private:
     int floatingPointPrecisionM;
     wxString dateFormatM;
     int maxBlobKBytesM;
@@ -49,6 +61,9 @@ private:
     bool showBlobContentM;
     wxString timeFormatM;
     wxString timestampFormatM;
+    ShowTimezoneInfoType showTimezoneInfoM;
+    void formatAppendTz(wxString &s, IBPP::Time &t, bool hasTz,
+        Database* db);
 protected:
     virtual void loadFromConfig();
 public:
@@ -59,9 +74,9 @@ public:
     template<typename T>
     wxString format(T value);
     wxString formatDate(int year, int month, int day);
-    wxString formatTime(int hour, int minute, int second, int milliSecond);
-    wxString formatTimestamp(int year, int month, int day,
-        int hour, int minute, int second, int milliSecond);
+    wxString formatTime(IBPP::Time &t, bool hasTz, Database* db);
+    wxString formatTimestamp(IBPP::Timestamp &ts, bool hasTz, Database* db);
+
     int maxBlobBytesToFetch();
     bool parseDate(wxString::iterator& start, wxString::iterator end,
         bool consumeAll, int& year, int& month, int& day);
@@ -86,7 +101,7 @@ public:
     virtual ~ResultsetColumnDef();
 
     virtual wxString getAsFirebirdString(DataGridRowBuffer* buffer);
-    virtual wxString getAsString(DataGridRowBuffer* buffer) = 0;
+    virtual wxString getAsString(DataGridRowBuffer* buffer, Database* db) = 0;
     virtual void setFromString(DataGridRowBuffer* buffer,
         const wxString& source) = 0;
     virtual unsigned getBufferSize() = 0;
@@ -96,7 +111,7 @@ public:
     bool isReadOnly();
     bool isNullable();
     virtual void setValue(DataGridRowBuffer* buffer, unsigned col,
-        const IBPP::Statement& statement, wxMBConv* converter) = 0;
+        const IBPP::Statement& statement, wxMBConv* converter, Database* db) = 0;
 };
 
 struct DataGridFieldInfo

--- a/src/ibpp/_ibpp.cpp
+++ b/src/ibpp/_ibpp.cpp
@@ -35,6 +35,8 @@
 #define REG_KEY_ROOT_INSTANCES	"SOFTWARE\\Firebird Project\\Firebird Server\\Instances"
 #define FB_DEFAULT_INSTANCE	  	"DefaultInstance"
 
+#endif
+
 #ifdef IBPP_UNIX
 #ifdef IBPP_LATE_BIND
 
@@ -51,8 +53,6 @@ static const char* fblibs[] = {"libfbembed.so.2.5","libfbembed.so.2.1","libfbcli
 // Many compilers confuses those following min/max with macros min and max !
 #undef min
 #undef max
-
-#endif
 
 namespace ibpp_internals
 {

--- a/src/ibpp/_ibpp.h
+++ b/src/ibpp/_ibpp.h
@@ -1408,8 +1408,12 @@ void decodeDate(IBPP::Date& dt, const ISC_DATE& isc_dt);
 void encodeTime(ISC_TIME& isc_tm, const IBPP::Time& tm);
 void decodeTime(IBPP::Time& tm, const ISC_TIME& isc_tm);
 
+void decodeTimeTz(IBPP::Time& tm, const ISC_TIME_TZ& isc_tm);
+
 void encodeTimestamp(ISC_TIMESTAMP& isc_ts, const IBPP::Timestamp& ts);
 void decodeTimestamp(IBPP::Timestamp& ts, const ISC_TIMESTAMP& isc_ts);
+
+void decodeTimestampTz(IBPP::Timestamp& ts, const ISC_TIMESTAMP_TZ& isc_ts);
 
 struct consts   // See _ibpp.cpp for initializations of these constants
 {

--- a/src/ibpp/ibase.h
+++ b/src/ibpp/ibase.h
@@ -189,9 +189,19 @@ typedef int			ISC_DATE;
 typedef unsigned int	ISC_TIME;
 typedef struct
 {
+	ISC_TIME utc_time;
+	ISC_USHORT time_zone;
+} ISC_TIME_TZ;
+typedef struct
+{
 	ISC_DATE timestamp_date;
 	ISC_TIME timestamp_time;
 } ISC_TIMESTAMP;
+typedef struct
+{
+	ISC_TIMESTAMP utc_timestamp;
+	ISC_USHORT time_zone;
+} ISC_TIMESTAMP_TZ;
 #define ISC_TIMESTAMP_DEFINED
 #endif	/* ISC_TIMESTAMP_DEFINED */
 
@@ -483,6 +493,8 @@ typedef struct
 #define SQL_TYPE_TIME                      560
 #define SQL_TYPE_DATE                      570
 #define SQL_INT64                          580
+#define SQL_TIMESTAMP_TZ                 32754
+#define SQL_TIME_TZ                      32756
 #define SQL_BOOLEAN                      32764
 #define SQL_NULL                         32766
 

--- a/src/ibpp/ibpp.h
+++ b/src/ibpp/ibpp.h
@@ -98,7 +98,8 @@ namespace IBPP
 
     //  SQL Data Types
     enum SDT {sdArray, sdBlob, sdDate, sdTime, sdTimestamp, sdString,
-        sdSmallint, sdInteger, sdLargeint, sdFloat, sdDouble, sdBoolean};
+        sdSmallint, sdInteger, sdLargeint, sdFloat, sdDouble, sdBoolean,
+		sdTimeTz, sdTimestampTz};
 
     //  Array Data Types
     enum ADT {adDate, adTime, adTimestamp, adString,
@@ -232,32 +233,54 @@ namespace IBPP
 
     class Time
     {
+	public:
+        enum TimezoneMode
+        {
+            // ISC_TIME / ISC_TIMESTAMP
+            tmNone,
+            // ISC_TIME_TZ / ISC_TIMESTAMP_TZ
+            tmTimezone,
+            // ISC_TIM_TZ_EX / ISC_TIMESTAMP_TZ_EX
+            tmTimezoneOffset
+        };
+		/* no time zone -> utc = local */
+		const static int TZ_NONE     =  0;
+		const static int TZ_DEFAULT  = -1;
+		/* time not initialized */
+		const static int TM_NOT_INIT = -1;
     protected:
-        int mTime;  // The time, in ten-thousandths of seconds since midnight
+        // The time, in ten-thousandths of seconds since midnight - UTC and TZ
+        mutable int mTime;
+        mutable TimezoneMode mTimezoneMode;
+        // The timezone
+        int mTimezone;
+        int mTimezoneOffset;
 
+        void SetTimezone(int tz);
     public:
-        void Clear()    { mTime = 0; }
+        void Clear()    { mTime = 0; mTimezoneMode = tmNone; mTimezone = TZ_NONE; mTimezoneOffset = 0;}
         void Now();
-        void SetTime(int hour, int minute, int second, int tenthousandths = 0);
-        void SetTime(int tm);
+        void SetTime(TimezoneMode tzMode, int hour, int minute, int second, int tenthousandths, int timezone);
+        void SetTime(TimezoneMode tzMode, int tm, int timezone);
+        //void SetTimezoneOffset(int ofs);
         void GetTime(int& hour, int& minute, int& second) const;
         void GetTime(int& hour, int& minute, int& second, int& tenthousandths) const;
-        int GetTime() const { return mTime; }
+        int GetTime() const;
+        int GetTimezone() const { return mTimezone; }
+        int GetTimezoneOffset() const { return mTimezoneOffset; }
         int Hours() const;
         int Minutes() const;
         int Seconds() const;
         int SubSeconds() const;     // Actually tenthousandths of seconds
         Time()          { Clear(); }
-        Time(int tm)    { SetTime(tm); }
-        Time(int hour, int minute, int second, int tenthousandths = 0);
+        Time(TimezoneMode tzMode, int tm, int timezone)    { SetTime(tzMode, tm, timezone); }
+        Time(TimezoneMode tzMode, int hour, int minute, int second, int tenthousandths, int timezone);
         Time(const Time&);                          // Copy Constructor
         Time& operator=(const Timestamp&);          // Timestamp Assignment operator
         Time& operator=(const Time&);               // Time Assignment operator
 
         bool operator==(const Time& rv) { return mTime == rv.GetTime(); }
         bool operator<(const Time& rv) { return mTime < rv.GetTime(); }
-
-        virtual ~Time() { }
     };
 
     /* Class Timestamp represent a date AND a time. It is usefull in
@@ -270,33 +293,33 @@ namespace IBPP
     public:
         void Clear()    { Date::Clear(); Time::Clear(); }
         void Today()    { Date::Today(); Time::Clear(); }
-        void Now()      { Date::Today(); Time::Now(); }
+        void Now(/*int timezone*/) { Date::Today(); Time::Now(/*timezone*/); }
 
         Timestamp()     { Clear(); }
 
         Timestamp(int y, int m, int d)
             { Date::SetDate(y, m, d); Time::Clear(); }
 
-        Timestamp(int y, int mo, int d, int h, int mi, int s, int t = 0)
-            { Date::SetDate(y, mo, d); Time::SetTime(h, mi, s, t); }
+        Timestamp(int y, int mo, int d, TimezoneMode tzMode, int h, int mi, int s, int t, int tz)
+            { Date::SetDate(y, mo, d); Time::SetTime(tzMode, h, mi, s, t, tz); }
 
         Timestamp(const Timestamp& rv)
-            : Date(rv.mDate), Time(rv.mTime) {} // Copy Constructor
+            : Date(rv.mDate), Time::Time(rv) {} // Copy Constructor
 
         Timestamp(const Date& rv)
-            { mDate = rv.GetDate(); mTime = 0; }
+            { mDate = rv.GetDate(); Time::Clear(); }
 
         Timestamp(const Time& rv)
-            { mDate = 0; mTime = rv.GetTime(); }
+            { mDate = 0; (Time)*this = rv; }
 
         Timestamp& operator=(const Timestamp& rv)   // Timestamp Assignment operator
-            { mDate = rv.mDate; mTime = rv.mTime; return *this; }
+            { mDate = rv.mDate; (Time)*this = (Time)rv; return *this; }
 
         Timestamp& operator=(const Date& rv)        // Date Assignment operator
             { mDate = rv.GetDate(); return *this; }
 
         Timestamp& operator=(const Time& rv)        // Time Assignment operator
-            { mTime = rv.GetTime(); return *this; }
+            { (Time)*this = (Time)rv; return *this; }
 
         bool operator==(const Timestamp& rv)
             { return (mDate == rv.GetDate()) && (mTime == rv.GetTime()); }

--- a/src/ibpp/row.cpp
+++ b/src/ibpp/row.cpp
@@ -698,6 +698,8 @@ IBPP::SDT RowImpl::ColumnType(int varnum)
 		case SQL_BLOB :      value = IBPP::sdBlob;      break;
 		case SQL_ARRAY :     value = IBPP::sdArray;     break;
 		case SQL_BOOLEAN :   value = IBPP::sdBoolean;     break;
+		case SQL_TIME_TZ :   value = IBPP::sdTimeTz;    break;
+		case SQL_TIMESTAMP_TZ : value = IBPP::sdTimestampTz; break;
 		default : throw LogicExceptionImpl("Row::ColumnType",
 						_("Found an unknown sqltype !"));
 	}
@@ -1363,6 +1365,22 @@ void* RowImpl::GetValue(int varnum, IITYPE ivType, void* retvalue)
 			}
 			break;
 
+		case SQL_TIMESTAMP_TZ :
+			if (ivType != ivTimestamp)
+				throw WrongTypeImpl("RowImpl::SetValue", var->sqltype, ivType,
+										_("Incompatible types."));
+			decodeTimestampTz(*(IBPP::Timestamp*)retvalue, *(ISC_TIMESTAMP_TZ*)var->sqldata);
+			value = retvalue;
+			break;
+
+		case SQL_TIME_TZ :
+			if (ivType != ivTime)
+				throw WrongTypeImpl("RowImpl::SetValue", var->sqltype, ivType,
+										_("Incompatible types."));
+			decodeTimeTz(*(IBPP::Time*)retvalue, *(ISC_TIME_TZ*)var->sqldata);
+			value = retvalue;
+			break;
+
 		default : throw LogicExceptionImpl("RowImpl::GetValue",
 						_("Found an unknown sqltype !"));
 	}
@@ -1394,6 +1412,8 @@ void RowImpl::Free()
 					case SQL_INT64 :	delete (int64_t*) var->sqldata; break;
 					case SQL_FLOAT : 	delete (float*) var->sqldata; break;
 					case SQL_DOUBLE :	delete (double*) var->sqldata; break;
+					case SQL_TIMESTAMP_TZ : delete (ISC_TIMESTAMP_TZ*) var->sqldata; break;
+					case SQL_TIME_TZ   : delete (ISC_TIME_TZ*) var->sqldata; break;
 					default : throw LogicExceptionImpl("RowImpl::Free",
 								_("Found an unknown sqltype !"));
 				}
@@ -1487,6 +1507,13 @@ void RowImpl::AllocVariables()
 			case SQL_INT64 :	var->sqldata = (char*) new int64_t(0); break;
 			case SQL_FLOAT : 	var->sqldata = (char*) new float(0.0); break;
 			case SQL_DOUBLE :	var->sqldata = (char*) new double(0.0); break;
+			case SQL_TIMESTAMP_TZ:
+								var->sqldata = (char*) new ISC_TIMESTAMP_TZ;
+								memset(var->sqldata, 0, sizeof(ISC_TIMESTAMP_TZ));
+								break;
+			case SQL_TIME_TZ :  var->sqldata = (char*) new ISC_TIME_TZ;
+								memset(var->sqldata, 0, sizeof(ISC_TIME_TZ));
+								break;
 			default : throw LogicExceptionImpl("RowImpl::AllocVariables",
 						_("Found an unknown sqltype !"));
 		}

--- a/src/ibpp/time.cpp
+++ b/src/ibpp/time.cpp
@@ -34,17 +34,20 @@ void IBPP::Time::Now()
 {
 	time_t systime = time(0);
 	tm* loctime = localtime(&systime);
-	IBPP::itot(&mTime, loctime->tm_hour, loctime->tm_min, loctime->tm_sec, 0);
+	SetTime(IBPP::Time::tmNone, loctime->tm_hour, loctime->tm_min, loctime->tm_sec, 0, IBPP::Time::TZ_NONE);
 }
 
-void IBPP::Time::SetTime(int tm)
+void IBPP::Time::SetTime(TimezoneMode tzMode, int tm, int timezone)
 {
-	if (tm < 0 || tm > 863999999)
-		throw LogicExceptionImpl("Time::SetTime", _("Invalid time value"));
-	mTime = tm;
+    if (tm < 0 || tm > 863999999)
+        throw LogicExceptionImpl("Time::SetTime", _("Invalid time value"));
+
+    mTime = tm;
+    mTimezoneMode = tzMode;
+    SetTimezone(timezone);
 }
 
-void IBPP::Time::SetTime(int hour, int minute, int second, int tenthousandths)
+void IBPP::Time::SetTime(TimezoneMode tzMode, int hour, int minute, int second, int tenthousandths, int timezone)
 {
 	if (hour < 0 || hour > 23 ||
 		minute < 0 || minute > 59 ||
@@ -52,17 +55,30 @@ void IBPP::Time::SetTime(int hour, int minute, int second, int tenthousandths)
 				tenthousandths < 0 || tenthousandths > 9999)
 					throw LogicExceptionImpl("Time::SetTime",
 						_("Invalid hour, minute, second values"));
-	IBPP::itot(&mTime, hour, minute, second, tenthousandths);
+	int tm;
+	IBPP::itot(&tm, hour, minute, second, tenthousandths);
+	SetTime(tzMode, tm, timezone);
+}
+
+void IBPP::Time::SetTimezone(int tz)
+{
+    mTimezone = tz;
+    mTimezoneOffset = 0;
+}
+
+int IBPP::Time::GetTime() const
+{
+    return mTime;
 }
 
 void IBPP::Time::GetTime(int& hour, int& minute, int& second) const
 {
-	IBPP::ttoi(mTime, &hour, &minute, &second, 0);
+	IBPP::ttoi(GetTime(), &hour, &minute, &second, 0);
 }
 
 void IBPP::Time::GetTime(int& hour, int& minute, int& second, int& tenthousandths) const
 {
-	IBPP::ttoi(mTime, &hour, &minute, &second, &tenthousandths);
+	IBPP::ttoi(GetTime(), &hour, &minute, &second, &tenthousandths);
 }
 
 int IBPP::Time::Hours() const
@@ -93,25 +109,32 @@ int IBPP::Time::SubSeconds() const	// Actually tenthousandths of seconds
 	return tenthousandths;
 }
 
-IBPP::Time::Time(int hour, int minute, int second, int tenthousandths)
+IBPP::Time::Time(TimezoneMode tzMode, int hour, int minute, int second, int tenthousandths, int timezone)
 {
-	SetTime(hour, minute, second, tenthousandths);
+	SetTime(tzMode, hour, minute, second, tenthousandths, timezone);
 }
 
 IBPP::Time::Time(const IBPP::Time& copied)
 {
 	mTime = copied.mTime;
+	mTimezoneMode = copied.mTimezoneMode;
+	mTimezone = copied.mTimezone;
+	mTimezoneOffset = copied.mTimezoneOffset;
 }
 
 IBPP::Time& IBPP::Time::operator=(const IBPP::Timestamp& assigned)
 {
 	mTime = assigned.GetTime();
+	mTimezone = assigned.GetTimezone();
+	mTimezoneOffset = assigned.GetTimezoneOffset();
 	return *this;
 }
 
 IBPP::Time& IBPP::Time::operator=(const IBPP::Time& assigned)
 {
 	mTime = assigned.mTime;
+	mTimezone = assigned.GetTimezone();
+	mTimezoneOffset = assigned.GetTimezoneOffset();
 	return *this;
 }
 
@@ -174,7 +197,12 @@ void encodeTime(ISC_TIME& isc_tm, const IBPP::Time& tm)
 
 void decodeTime(IBPP::Time& tm, const ISC_TIME& isc_tm)
 {
-	tm.SetTime((int)isc_tm);
+	tm.SetTime(IBPP::Time::tmNone, (int)isc_tm, IBPP::Time::TZ_NONE);
+}
+
+void decodeTimeTz(IBPP::Time& tm, const ISC_TIME_TZ& isc_tm)
+{
+	tm.SetTime(IBPP::Time::tmTimezone, (int)isc_tm.utc_time, isc_tm.time_zone);
 }
 
 void encodeTimestamp(ISC_TIMESTAMP& isc_ts, const IBPP::Timestamp& ts)
@@ -187,6 +215,12 @@ void decodeTimestamp(IBPP::Timestamp& ts, const ISC_TIMESTAMP& isc_ts)
 {
 	decodeDate(ts, isc_ts.timestamp_date);
 	decodeTime(ts, isc_ts.timestamp_time);
+}
+
+void decodeTimestampTz(IBPP::Timestamp& ts, const ISC_TIMESTAMP_TZ& isc_ts)
+{
+	decodeDate(ts, isc_ts.utc_timestamp.timestamp_date);
+	ts.SetTime(IBPP::Time::tmTimezone, (int)isc_ts.utc_timestamp.timestamp_time, isc_ts.time_zone);
 }
 
 }

--- a/src/metadata/database.cpp
+++ b/src/metadata/database.cpp
@@ -318,6 +318,8 @@ Database::Database()
     : MetadataItem(ntDatabase), metadataLoaderM(0), connectedM(false),
         connectionCredentialsM(0), dialectM(3), idM(0)
 {
+    defaultTimezoneM.name = "";
+    defaultTimezoneM.id = 0;
 }
 
 Database::~Database()
@@ -1163,6 +1165,10 @@ void Database::connect(const wxString& password, ProgressIndicator* indicator)
                 dialectM = databaseM->Dialect();
                 databaseInfoM.load(databaseM);
                 setPropertiesLoaded(true);
+
+                // load default timezone
+                loadDefaultTimezone();
+                loadTimezones();
 
                 // load collections of metadata objects
                 setChildrenLoaded(false);
@@ -2014,3 +2020,78 @@ void Database::checkConnected(const wxString& operation) const
     }
 }
 
+void Database::loadDefaultTimezone()
+{
+    MetadataLoader* loader = getMetadataLoader();
+    wxMBConv* converter = getCharsetConverter();
+    std::string tzName;
+    int tzId;
+
+    // RDB$TIME_ZONES is available on Firebird 4 (ODS Ver 13) or higher
+    if (!getInfo().getODSVersionIsHigherOrEqualTo(13, 0))
+        return;
+
+    IBPP::Statement& st1 = loader->getStatement(
+        "select z.RDB$TIME_ZONE_ID, "
+        "       z.RDB$TIME_ZONE_NAME "
+        "from RDB$TIME_ZONES z "
+        "where z.RDB$TIME_ZONE_NAME = RDB$GET_CONTEXT('SYSTEM', 'SESSION_TIMEZONE');");
+
+    st1->Execute();
+    st1->Fetch();
+    st1->Get(1, tzId);
+    st1->Get(2, tzName);
+
+    defaultTimezoneM.id = tzId;
+    defaultTimezoneM.name = std2wxIdentifier(tzName, converter);
+}
+
+void Database::loadTimezones()
+{
+    MetadataLoader* loader = getMetadataLoader();
+    wxMBConv* converter = getCharsetConverter();
+    std::string tzName;
+    int tzId;
+    TimezoneInfo* tzItm;
+
+    // RDB$TIME_ZONES is available on Firebird 4 (ODS Ver 13) or higher
+    if (!getInfo().getODSVersionIsHigherOrEqualTo(13, 0))
+        return;
+
+    IBPP::Statement& st1 = loader->getStatement(
+        "select z.RDB$TIME_ZONE_ID, "
+        "       z.RDB$TIME_ZONE_NAME "
+        "from RDB$TIME_ZONES z");
+
+    st1->Execute();
+
+    while (st1->Fetch())
+    {
+        st1->Get(1, tzId);
+        st1->Get(2, tzName);
+
+        tzItm = new TimezoneInfo;
+        tzItm->id = tzId;
+        tzItm->name = std2wxIdentifier(tzName, converter);
+        timezonesM.push_back(tzItm);
+    }
+}
+
+TimezoneInfo Database::getDefaultTimezone()
+{
+    loadDefaultTimezone();
+    return defaultTimezoneM;
+}
+
+wxString Database::getTimezoneName(int timezone)
+{
+    std::vector<TimezoneInfo*>::iterator it;
+    for (it = timezonesM.begin(); it != timezonesM.end(); it++)
+    {
+        if ((*it)->id != timezone)
+            continue;
+        return (*it)->name;
+    }
+    // not found
+    return wxString::Format("TZ %d", timezone);
+}

--- a/src/metadata/database.h
+++ b/src/metadata/database.h
@@ -142,6 +142,17 @@ private:
     Mode modeM;
 };
 
+class TimezoneInfo
+{
+public:
+    TimezoneInfo() { name = ""; id = 0; };
+
+    bool empty() { return (name == "") && (id == 0); };
+
+    wxString name;
+    uint16_t id;
+};
+
 class Database: public MetadataItem,
     public std::enable_shared_from_this<Database>
 {
@@ -163,6 +174,8 @@ private:
     Credentials credentialsM;
     Credentials* connectionCredentialsM;
     DatabaseAuthenticationMode authenticationModeM;
+    std::vector<TimezoneInfo*> timezonesM;
+    TimezoneInfo defaultTimezoneM;
 
     std::unique_ptr<wxMBConv> charsetConverterM;
     void createCharsetConverter();
@@ -200,6 +213,9 @@ private:
     void loadCollations();
 
     void loadCollections(ProgressIndicator* progressIndicator);
+
+    void loadDefaultTimezone();
+    void loadTimezones();
 
     // small help for parser
     wxString getTableForIndex(const wxString& indexName);
@@ -277,6 +293,9 @@ public:
     CharacterSet getCharsetById(int id);
     wxArrayString getCollations(const wxString& charset);
     bool isDefaultCollation(const wxString& charset, const wxString& collate);
+
+    TimezoneInfo getDefaultTimezone();
+    wxString getTimezoneName(int timezone);
 
     //! fill vector with names of all tables, views, etc.
     void getIdentifiers(std::vector<Identifier>& temp);


### PR DESCRIPTION
Add time zone support for firebird 4

Add a new option to "Data Grid"-preferences to select how time zones are displayed: none, id or name.

To display the names of the time zones the table RDB$TIME_ZONES is loaded. This is done when opening a database (ODS version >= 13.0).