### PR TITLE
FB Library Search

### DIFF
--- a/conf-defs/fr_settings.confdef
+++ b/conf-defs/fr_settings.confdef
@@ -38,6 +38,12 @@
                 </setting>
             </enables>
         </setting>
+                <setting type="file">
+                    <caption>Library file name:</caption>
+                    <description>FbClient.dll or gds32.dll </description>
+                    <key>LibraryFile</key>
+                </setting>
+		
         <!--
         <setting type="checkbox">
             <caption>Confirm quit</caption>

--- a/flamerobin_flamerobin.vcxproj
+++ b/flamerobin_flamerobin.vcxproj
@@ -402,14 +402,14 @@
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;__WXDEBUG__;_DEBUG;_WINDOWS;__WINDOWS__;WINVER=0x400;WIN32;__WIN32__;__WIN95__;STRICT;__WXMSW__;wxUSE_GUI=1;wxUSE_REGEX=1;wxUSE_UNICODE=1;WIN32_LEAN_AND_MEAN;_WINDOWS;IBPP_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
-      <AdditionalIncludeDirectories>$(WXDIR)\lib\vc_lib\mswud;$(WXDIR)\contrib\include;$(WXDIR)\include;$(BOOST_ROOT);.;.\src;.\src\ibpp;.\res;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WXDIR)\lib\vc_lib\mswud;$(WXDIR)\contrib\include;$(WXDIR)\include;.;.\src;.\src\ibpp;.\res;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
       <AdditionalOptions>/nologo /subsystem:windows %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>wxmsw31ud_aui.lib;wxmsw31ud_stc.lib;wxmsw31ud_html.lib;wxmsw31ud_adv.lib;wxmsw31ud_core.lib;wxbase31ud_xml.lib;wxbase31ud.lib;wxscintillad.lib;wxexpatd.lib;wxtiffd.lib;wxjpegd.lib;wxpngd.lib;wxzlibd.lib;wxregexud.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;comctl32.lib;rpcrt4.lib;wsock32.lib;vcusd\ibpp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>flamerobin.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>$(WXDIR)\lib\vc_lib;$(BOOST_LIB_DIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(WXDIR)\lib\vc_lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>vcusd\flamerobin.pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>

--- a/flamerobin_flamerobin.vcxproj.filters
+++ b/flamerobin_flamerobin.vcxproj.filters
@@ -16,133 +16,139 @@
     <Filter Include="Source Files\Metadata">
       <UniqueIdentifier>{0f09e77a-5c5b-43de-8cca-a5e23a946588}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\gui">
+      <UniqueIdentifier>{66289fbe-1c79-498d-adfc-caae5c0e9e11}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\sql">
+      <UniqueIdentifier>{06d639b2-18b7-4a91-932f-f7e78d6e8308}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\gui\AboutBox.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\AdvancedMessageDialog.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\AdvancedSearchFrame.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\core\ArtProvider.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\BackupFrame.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\BackupRestoreBaseFrame.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\BaseDialog.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\BaseFrame.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\core\CodeTemplateProcessor.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\CommandManager.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\ConfdefTemplateProcessor.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\config\Config.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\ContextMenuMetadataItemVisitor.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\controls\ControlUtils.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\metadata\CreateDDLVisitor.cpp">
       <Filter>Source Files\Metadata</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\CreateIndexDialog.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\controls\DBHTreeControl.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\DataGeneratorFrame.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\controls\DataGrid.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\controls\DataGridRowBuffer.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\controls\DataGridRows.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\controls\DataGridTable.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\config\DatabaseConfig.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\DatabaseRegistrationDialog.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\controls\DndTextControls.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\EditBlobDialog.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\EventWatcherFrame.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\ExecuteSql.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\ExecuteSqlFrame.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\core\FRError.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\FRLayoutConfig.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\FieldPropertiesDialog.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\FindDialog.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\GUIURIHandlerHelper.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\HtmlHeaderMetadataItemVisitor.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\HtmlTemplateProcessor.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\sql\Identifier.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\sql</Filter>
     </ClCompile>
     <ClCompile Include="src\sql\IncompleteStatement.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\sql</Filter>
     </ClCompile>
     <ClCompile Include="src\metadata\Index.cpp">
       <Filter>Source Files\Metadata</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\InsertDialog.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\controls\LogTextControl.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\MainFrame.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\MasterPassword.cpp">
       <Filter>Source Files</Filter>
@@ -154,7 +160,7 @@
       <Filter>Source Files\Metadata</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\MetadataItemPropertiesFrame.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\metadata\MetadataItemURIHandlerHelper.cpp">
       <Filter>Source Files\Metadata</Filter>
@@ -172,67 +178,67 @@
       <Filter>Source Files\Metadata</Filter>
     </ClCompile>
     <ClCompile Include="src\sql\MultiStatement.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\sql</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\MultilineEnterDialog.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\core\Observer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\PreferencesDialog.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\PreferencesDialogSettings.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\controls\PrintableHtmlWindow.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\PrivilegesDialog.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\ProgressDialog.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\core\ProgressIndicator.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\ReorderFieldsDialog.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\RestoreFrame.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\sql\SelectStatement.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\sql</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\ServerRegistrationDialog.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\SimpleHtmlFrame.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\sql\SqlStatement.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\sql</Filter>
     </ClCompile>
     <ClCompile Include="src\sql\SqlTokenizer.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\sql</Filter>
     </ClCompile>
     <ClCompile Include="src\sql\StatementBuilder.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\sql</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\StatementHistoryDialog.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\core\StringUtils.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\StyleGuide.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\msw\StyleGuideMSW.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\core\Subject.cpp">
       <Filter>Source Files</Filter>
@@ -241,7 +247,7 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\controls\TextControl.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\core\URIProcessor.cpp">
       <Filter>Source Files</Filter>
@@ -250,10 +256,10 @@
       <Filter>Source Files\Metadata</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\UserDialog.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\UsernamePasswordDialog.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\core\Visitor.cpp">
       <Filter>Source Files</Filter>
@@ -337,7 +343,7 @@
       <Filter>Source Files\Metadata</Filter>
     </ClCompile>
     <ClCompile Include="src\gui\InsertParametersDialog.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\gui</Filter>
     </ClCompile>
     <ClCompile Include="src\metadata\package.cpp">
       <Filter>Source Files\Metadata</Filter>

--- a/src/gui/DatabaseRegistrationDialog.cpp
+++ b/src/gui/DatabaseRegistrationDialog.cpp
@@ -94,13 +94,15 @@ void DatabaseRegistrationDialog::createControls()
 
     label_role = new wxStaticText(getControlsPanel(), -1, _("Role:"));
     text_ctrl_role = new wxTextCtrl(getControlsPanel(), -1, "");
-
+    /*
+    Todo: Implement FB library per conexion
     label_library = new wxStaticText(getControlsPanel(), -1,
         _("Library path:"));
     text_ctrl_library = new FileTextControl(getControlsPanel(),
         ID_textcontrol_library, wxEmptyString);
     button_browse_library = new wxButton(getControlsPanel(), ID_button_browse_library,
         "...", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
+     */
 
 
     if (createM)
@@ -294,20 +296,22 @@ void DatabaseRegistrationDialog::layoutControls()
     sizerControls->Add(combobox_charset, wxGBPosition(4, 1), wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxEXPAND);
     sizerControls->Add(label_role, wxGBPosition(4, 2), wxDefaultSpan, wxLEFT | wxALIGN_CENTER_VERTICAL, dx);
     sizerControls->Add(text_ctrl_role, wxGBPosition(4, 3), wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxEXPAND);
-
+    
+    /*
+    * Todo: Implement FB library per conexion
     sizerControls->Add(label_library, wxGBPosition(5, 0), wxDefaultSpan, wxALIGN_CENTER_VERTICAL);
     wxBoxSizer* sizer_r1c1_4 = new wxBoxSizer(wxHORIZONTAL);
     sizer_r1c1_4->Add(text_ctrl_library, 1, wxALIGN_CENTER_VERTICAL);
     sizer_r1c1_4->Add(button_browse_library, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, styleguide().getBrowseButtonMargin());
     sizerControls->Add(sizer_r1c1_4, wxGBPosition(5, 1), wxGBSpan(1, 3), wxEXPAND);
-
+    */
 
     if (createM)
     {
-        sizerControls->Add(label_pagesize, wxGBPosition(6, 0), wxDefaultSpan, wxALIGN_CENTER_VERTICAL);
-        sizerControls->Add(choice_pagesize, wxGBPosition(6, 1), wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxEXPAND);
-        sizerControls->Add(label_dialect, wxGBPosition(6, 2), wxDefaultSpan, wxLEFT | wxALIGN_CENTER_VERTICAL, dx);
-        sizerControls->Add(choice_dialect, wxGBPosition(6, 3), wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxEXPAND);
+        sizerControls->Add(label_pagesize, wxGBPosition(5, 0), wxDefaultSpan, wxALIGN_CENTER_VERTICAL);
+        sizerControls->Add(choice_pagesize, wxGBPosition(5, 1), wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxEXPAND);
+        sizerControls->Add(label_dialect, wxGBPosition(5, 2), wxDefaultSpan, wxLEFT | wxALIGN_CENTER_VERTICAL, dx);
+        sizerControls->Add(choice_dialect, wxGBPosition(5, 3), wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxEXPAND);
     }
 
     sizerControls->AddGrowableCol(1);
@@ -348,8 +352,10 @@ void DatabaseRegistrationDialog::setDatabase(DatabasePtr db)
     text_ctrl_username->SetValue(databaseM->getUsername());
     text_ctrl_password->SetValue(databaseM->getDecryptedPassword());
     text_ctrl_role->SetValue(databaseM->getRole());
+    /*
+    * Todo: Implement FB library per conexion
     text_ctrl_library->SetValue(databaseM->getClientLibrary());
-
+    */
     wxString charset(databaseM->getConnectionCharset());
     if (charset.empty())
         charset = "NONE";
@@ -439,11 +445,14 @@ void DatabaseRegistrationDialog::OnBrowseButtonClick(wxCommandEvent& WXUNUSED(ev
 
 void DatabaseRegistrationDialog::OnBrowseLibraryButtonClick(wxCommandEvent& WXUNUSED(event))
 {
+    /*
+    * Todo: Implement FB library per conexion
     wxString path = ::wxFileSelector(_("Select library file"), "", "", "",
         _("Firebird library files (*.dll)|*.dll|All files (*.*)|*.*"),
         wxFD_OPEN, this);
     if (!path.empty())
         text_ctrl_library->SetValue(path);
+     */
 }
 
 void DatabaseRegistrationDialog::OnOkButtonClick(wxCommandEvent& WXUNUSED(event))
@@ -466,7 +475,10 @@ void DatabaseRegistrationDialog::OnOkButtonClick(wxCommandEvent& WXUNUSED(event)
     databaseM->setPath(text_ctrl_dbpath->GetValue());
     databaseM->setUsername(text_ctrl_username->GetValue());
     databaseM->setEncryptedPassword(text_ctrl_password->GetValue());
+    /*
+    * Todo: Implement FB library per conexion
     databaseM->setClientLibrary(text_ctrl_library->GetValue());
+    */
 
     wxBusyCursor wait;
     databaseM->setConnectionCharset(combobox_charset->GetValue());

--- a/src/gui/DatabaseRegistrationDialog.cpp
+++ b/src/gui/DatabaseRegistrationDialog.cpp
@@ -85,7 +85,7 @@ void DatabaseRegistrationDialog::createControls()
 
     label_charset = new wxStaticText(getControlsPanel(), -1, _("Charset:"));
     long comboStyle =  wxCB_DROPDOWN;
-#ifndef __WXMAC__l
+#ifndef __WXMAC__
     // Not supported on OSX/Cocoa presently
     comboStyle |= wxCB_SORT;
 #endif

--- a/src/gui/DatabaseRegistrationDialog.cpp
+++ b/src/gui/DatabaseRegistrationDialog.cpp
@@ -61,6 +61,7 @@ void DatabaseRegistrationDialog::createControls()
     label_name = new wxStaticText(getControlsPanel(), -1, _("Display name:"));
     text_ctrl_name = new wxTextCtrl(getControlsPanel(),
         ID_textcontrol_name, wxEmptyString);
+
     label_dbpath = new wxStaticText(getControlsPanel(), -1,
         _("Database path:"));
     text_ctrl_dbpath = new FileTextControl(getControlsPanel(),
@@ -84,7 +85,7 @@ void DatabaseRegistrationDialog::createControls()
 
     label_charset = new wxStaticText(getControlsPanel(), -1, _("Charset:"));
     long comboStyle =  wxCB_DROPDOWN;
-#ifndef __WXMAC__
+#ifndef __WXMAC__l
     // Not supported on OSX/Cocoa presently
     comboStyle |= wxCB_SORT;
 #endif
@@ -93,6 +94,14 @@ void DatabaseRegistrationDialog::createControls()
 
     label_role = new wxStaticText(getControlsPanel(), -1, _("Role:"));
     text_ctrl_role = new wxTextCtrl(getControlsPanel(), -1, "");
+
+    label_library = new wxStaticText(getControlsPanel(), -1,
+        _("Library path:"));
+    text_ctrl_library = new FileTextControl(getControlsPanel(),
+        ID_textcontrol_library, wxEmptyString);
+    button_browse_library = new wxButton(getControlsPanel(), ID_button_browse_library,
+        "...", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
+
 
     if (createM)
     {
@@ -286,12 +295,19 @@ void DatabaseRegistrationDialog::layoutControls()
     sizerControls->Add(label_role, wxGBPosition(4, 2), wxDefaultSpan, wxLEFT | wxALIGN_CENTER_VERTICAL, dx);
     sizerControls->Add(text_ctrl_role, wxGBPosition(4, 3), wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxEXPAND);
 
+    sizerControls->Add(label_library, wxGBPosition(5, 0), wxDefaultSpan, wxALIGN_CENTER_VERTICAL);
+    wxBoxSizer* sizer_r1c1_4 = new wxBoxSizer(wxHORIZONTAL);
+    sizer_r1c1_4->Add(text_ctrl_library, 1, wxALIGN_CENTER_VERTICAL);
+    sizer_r1c1_4->Add(button_browse_library, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, styleguide().getBrowseButtonMargin());
+    sizerControls->Add(sizer_r1c1_4, wxGBPosition(5, 1), wxGBSpan(1, 3), wxEXPAND);
+
+
     if (createM)
     {
-        sizerControls->Add(label_pagesize, wxGBPosition(5, 0), wxDefaultSpan, wxALIGN_CENTER_VERTICAL);
-        sizerControls->Add(choice_pagesize, wxGBPosition(5, 1), wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxEXPAND);
-        sizerControls->Add(label_dialect, wxGBPosition(5, 2), wxDefaultSpan, wxLEFT | wxALIGN_CENTER_VERTICAL, dx);
-        sizerControls->Add(choice_dialect, wxGBPosition(5, 3), wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxEXPAND);
+        sizerControls->Add(label_pagesize, wxGBPosition(6, 0), wxDefaultSpan, wxALIGN_CENTER_VERTICAL);
+        sizerControls->Add(choice_pagesize, wxGBPosition(6, 1), wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxEXPAND);
+        sizerControls->Add(label_dialect, wxGBPosition(6, 2), wxDefaultSpan, wxLEFT | wxALIGN_CENTER_VERTICAL, dx);
+        sizerControls->Add(choice_dialect, wxGBPosition(6, 3), wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxEXPAND);
     }
 
     sizerControls->AddGrowableCol(1);
@@ -332,6 +348,8 @@ void DatabaseRegistrationDialog::setDatabase(DatabasePtr db)
     text_ctrl_username->SetValue(databaseM->getUsername());
     text_ctrl_password->SetValue(databaseM->getDecryptedPassword());
     text_ctrl_role->SetValue(databaseM->getRole());
+    text_ctrl_library->SetValue(databaseM->getClientLibrary());
+
     wxString charset(databaseM->getConnectionCharset());
     if (charset.empty())
         charset = "NONE";
@@ -401,11 +419,13 @@ void DatabaseRegistrationDialog::updateIsDefaultDatabaseName()
 //! event handling
 BEGIN_EVENT_TABLE(DatabaseRegistrationDialog, BaseDialog)
     EVT_BUTTON(DatabaseRegistrationDialog::ID_button_browse, DatabaseRegistrationDialog::OnBrowseButtonClick)
+    EVT_BUTTON(DatabaseRegistrationDialog::ID_button_browse_library, DatabaseRegistrationDialog::OnBrowseLibraryButtonClick)
     EVT_BUTTON(wxID_SAVE, DatabaseRegistrationDialog::OnOkButtonClick)
     EVT_TEXT(DatabaseRegistrationDialog::ID_textcontrol_dbpath, DatabaseRegistrationDialog::OnSettingsChange)
     EVT_TEXT(DatabaseRegistrationDialog::ID_textcontrol_name, DatabaseRegistrationDialog::OnNameChange)
     EVT_TEXT(DatabaseRegistrationDialog::ID_textcontrol_username, DatabaseRegistrationDialog::OnSettingsChange)
     EVT_CHOICE(DatabaseRegistrationDialog::ID_choice_authentication, DatabaseRegistrationDialog::OnAuthenticationChange)
+    EVT_TEXT(DatabaseRegistrationDialog::ID_textcontrol_library, DatabaseRegistrationDialog::OnSettingsChange)
 END_EVENT_TABLE()
 
 void DatabaseRegistrationDialog::OnBrowseButtonClick(wxCommandEvent& WXUNUSED(event))
@@ -415,6 +435,15 @@ void DatabaseRegistrationDialog::OnBrowseButtonClick(wxCommandEvent& WXUNUSED(ev
         wxFD_OPEN, this);
     if (!path.empty())
         text_ctrl_dbpath->SetValue(path);
+}
+
+void DatabaseRegistrationDialog::OnBrowseLibraryButtonClick(wxCommandEvent& WXUNUSED(event))
+{
+    wxString path = ::wxFileSelector(_("Select library file"), "", "", "",
+        _("Firebird library files (*.dll)|*.dll|All files (*.*)|*.*"),
+        wxFD_OPEN, this);
+    if (!path.empty())
+        text_ctrl_library->SetValue(path);
 }
 
 void DatabaseRegistrationDialog::OnOkButtonClick(wxCommandEvent& WXUNUSED(event))
@@ -437,6 +466,7 @@ void DatabaseRegistrationDialog::OnOkButtonClick(wxCommandEvent& WXUNUSED(event)
     databaseM->setPath(text_ctrl_dbpath->GetValue());
     databaseM->setUsername(text_ctrl_username->GetValue());
     databaseM->setEncryptedPassword(text_ctrl_password->GetValue());
+    databaseM->setClientLibrary(text_ctrl_library->GetValue());
 
     wxBusyCursor wait;
     databaseM->setConnectionCharset(combobox_charset->GetValue());

--- a/src/gui/DatabaseRegistrationDialog.h
+++ b/src/gui/DatabaseRegistrationDialog.h
@@ -65,11 +65,13 @@ private:
     
     wxStaticText* label_dialect;
     wxChoice* choice_dialect;
-
+    
+    /*
+    * Todo: Implement FB library per conexion
     wxStaticText* label_library;
     FileTextControl* text_ctrl_library;
     wxButton* button_browse_library;
-
+    */
 
     wxButton* button_ok;
     wxButton* button_cancel;

--- a/src/gui/DatabaseRegistrationDialog.h
+++ b/src/gui/DatabaseRegistrationDialog.h
@@ -40,23 +40,37 @@ private:
 
     wxStaticText* label_name;
     wxTextCtrl* text_ctrl_name;
+
     wxStaticText* label_dbpath;
     FileTextControl* text_ctrl_dbpath;
     wxButton* button_browse;
+    
     wxStaticText* label_authentication;
     wxChoice* choice_authentication;
+    
     wxStaticText* label_username;
     wxTextCtrl* text_ctrl_username;
+    
     wxStaticText* label_password;
     wxTextCtrl* text_ctrl_password;
+    
     wxStaticText* label_charset;
     wxComboBox* combobox_charset;
+    
     wxStaticText* label_role;
     wxTextCtrl* text_ctrl_role;
+    
     wxStaticText* label_pagesize;
     wxChoice* choice_pagesize;
+    
     wxStaticText* label_dialect;
     wxChoice* choice_dialect;
+
+    wxStaticText* label_library;
+    FileTextControl* text_ctrl_library;
+    wxButton* button_browse_library;
+
+
     wxButton* button_ok;
     wxButton* button_cancel;
 
@@ -92,11 +106,14 @@ private:
         ID_textcontrol_username,
         ID_textcontrol_password,
         ID_button_browse,
-        ID_choice_authentication
+        ID_choice_authentication,
+        ID_textcontrol_library,
+        ID_button_browse_library
     };
 
     void OnAuthenticationChange(wxCommandEvent& event);
     void OnBrowseButtonClick(wxCommandEvent& event);
+    void OnBrowseLibraryButtonClick(wxCommandEvent& event);
     void OnNameChange(wxCommandEvent& event);
     void OnOkButtonClick(wxCommandEvent& event);
     void OnSettingsChange(wxCommandEvent& event);

--- a/src/gui/MetadataItemPropertiesFrame.cpp
+++ b/src/gui/MetadataItemPropertiesFrame.cpp
@@ -607,6 +607,9 @@ void MetadataItemPropertiesFrame::showPanel(MetadataItemPropertiesPanel* panel,
         notebookM->SetSelection(pg);
 
     Show();
+    if (!IsMaximized())
+        Maximize(true);
+
     if (panel)
         panel->SetFocus();
     Raise();

--- a/src/gui/ServerRegistrationDialog.cpp
+++ b/src/gui/ServerRegistrationDialog.cpp
@@ -107,7 +107,8 @@ void ServerRegistrationDialog::layoutControls()
     // create sizer for controls
     wxFlexGridSizer* sizerControls = new wxFlexGridSizer(3, 2,
         styleguide().getRelatedControlMargin(wxVERTICAL),
-        styleguide().getControlLabelMargin());
+        styleguide().getControlLabelMargin()
+    );
     sizerControls->AddGrowableCol(1);
 
     sizerControls->Add(label_name, 0, wxALIGN_CENTER_VERTICAL);

--- a/src/ibpp/_ibpp.cpp
+++ b/src/ibpp/_ibpp.cpp
@@ -348,9 +348,12 @@ namespace IBPP
 	//	Factories for our Interface objects
 
     Service ServiceFactory(const std::string& ServerName,
-				const std::string& UserName, const std::string& UserPassword)
+				const std::string& UserName, const std::string& UserPassword,
+                const std::string& FBClient )
 	{
-		(void)gds.Call();			// Triggers the initialization, if needed
+        if (FBClient.length() != 0)
+            gds.mfbdll = FBClient;
+        (void)gds.Call();			// Triggers the initialization, if needed
 		return new ServiceImpl(ServerName, UserName, UserPassword);
 	}
 
@@ -371,35 +374,35 @@ namespace IBPP
 	Transaction TransactionFactory(Database db, TAM am,
 					TIL il, TLR lr, TFF flags)
 	{
-		(void)gds.Call();			// Triggers the initialization, if needed
+        (void)gds.Call();			// Triggers the initialization, if needed
 		return new TransactionImpl(	dynamic_cast<DatabaseImpl*>(db.intf()),
 									am, il, lr, flags);
 	}
 
 	Statement StatementFactory(Database db, Transaction tr)
 	{
-		(void)gds.Call();			// Triggers the initialization, if needed
+        (void)gds.Call();			// Triggers the initialization, if needed
 		return new StatementImpl(	dynamic_cast<DatabaseImpl*>(db.intf()),
 									dynamic_cast<TransactionImpl*>(tr.intf()));
 	}
 
 	Blob BlobFactory(Database db, Transaction tr)
 	{
-		(void)gds.Call();			// Triggers the initialization, if needed
+        (void)gds.Call();			// Triggers the initialization, if needed
 		return new BlobImpl(dynamic_cast<DatabaseImpl*>(db.intf()),
 							dynamic_cast<TransactionImpl*>(tr.intf()));
 	}
 
 	Array ArrayFactory(Database db, Transaction tr)
 	{
-		(void)gds.Call();			// Triggers the initialization, if needed
+        (void)gds.Call();			// Triggers the initialization, if needed
 		return new ArrayImpl(dynamic_cast<DatabaseImpl*>(db.intf()),
 							dynamic_cast<TransactionImpl*>(tr.intf()));
 	}
 
 	Events EventsFactory(Database db)
 	{
-		(void)gds.Call();			// Triggers the initialization, if needed
+        (void)gds.Call();			// Triggers the initialization, if needed
 		return new EventsImpl(dynamic_cast<DatabaseImpl*>(db.intf()));
 	}
 

--- a/src/ibpp/_ibpp.cpp
+++ b/src/ibpp/_ibpp.cpp
@@ -76,7 +76,7 @@ namespace ibpp_internals
 		if (std::stringstream* p = dynamic_cast<std::stringstream*>(&a))
 		{
 #ifdef IBPP_WINDOWS
-			::OutputDebugStringA(("IBPP: " + p->str() + "\n").c_str());
+			::OutputDebugString(("IBPP: " + p->str() + "\n").c_str());
 #endif
 			p->str("");
 		}
@@ -107,24 +107,34 @@ FBCLIENT* FBCLIENT::Call()
 		// that may have been specified through ClientLibSearchPaths().
 		mHandle = 0;
 
-		std::string::size_type pos = 0;
-		while (pos < mSearchPaths.size())
-		{
-			std::string::size_type newpos = mSearchPaths.find(';', pos);
+        // try specific library
+        if (lstrlen(mfbdll.c_str()) > 0)
+            mHandle = LoadLibrary(mfbdll.c_str());
 
-			std::string path;
-			if (newpos == std::string::npos) path = mSearchPaths.substr(pos);
-			else path = mSearchPaths.substr(pos, newpos-pos);
+        if (mHandle == 0) {
+            std::string::size_type pos = 0;
+            while (pos < mSearchPaths.size())
+            {
+                std::string::size_type newpos = mSearchPaths.find(';', pos);
 
-			if (path.size() >= 1)
-			{
-				if (path[path.size()-1] != '\\') path += '\\';
-				path.append("fbclient.dll");
-				mHandle = LoadLibraryA(path.c_str());
-				if (mHandle != 0 || newpos == std::string::npos) break;
-			}
-			pos = newpos + 1;
-		}
+                std::string path;
+                if (newpos == std::string::npos) 
+                    path = mSearchPaths.substr(pos);
+                else 
+                    path = mSearchPaths.substr(pos, newpos - pos);
+
+                if (path.size() >= 1)
+                {
+                    if (path[path.size() - 1] != '\\') 
+                        path += '\\';
+                    path.append("fbclient.dll");
+                    mHandle = LoadLibrary(path.c_str());
+                    if (mHandle != 0 || newpos == std::string::npos) 
+                        break;
+                }
+                pos = newpos + 1;
+            }
+        }
 
 		if (mHandle == 0)
 		{
@@ -132,7 +142,7 @@ FBCLIENT* FBCLIENT::Call()
 			// is a usefull step for applications using the embedded version of FB
 			// or a local copy (for whatever reasons) of the dll.
 
-			int len = GetModuleFileNameA(NULL, fbdll, sizeof(fbdll));
+			int len = GetModuleFileName(NULL, fbdll, sizeof(fbdll));
 			if (len != 0)
 			{
 				// Get to the last '\' (this one precedes the filename part).
@@ -140,13 +150,13 @@ FBCLIENT* FBCLIENT::Call()
 				char* p = fbdll + len;
 				do {--p;} while (*p != '\\');
 				*p = '\0';
-				lstrcatA(fbdll, "\\fbembed.dll");// Local copy could be named fbembed.dll
-				mHandle = LoadLibraryA(fbdll);
+				lstrcat(fbdll, "\\fbembed.dll");// Local copy could be named fbembed.dll
+				mHandle = LoadLibrary(fbdll);
 				if (mHandle == 0)
 				{
 					*p = '\0';
-					lstrcatA(fbdll, "\\fbclient.dll");	// Or possibly renamed fbclient.dll
-					mHandle = LoadLibraryA(fbdll);
+					lstrcat(fbdll, "\\fbclient.dll");	// Or possibly renamed fbclient.dll
+					mHandle = LoadLibrary(fbdll);
 				}
 			}
 		}
@@ -158,10 +168,10 @@ FBCLIENT* FBCLIENT::Call()
 			// of IBPP in order to be able to select among multiple instances
 			// that Firebird Server version > 1.5 might introduce.
 
-			if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, REG_KEY_ROOT_INSTANCES, 0,
+			if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, REG_KEY_ROOT_INSTANCES, 0,
 					KEY_READ, &hkey_instances) == ERROR_SUCCESS
 				// try 64 bit registry view for 32 bit client program with 64 bit server
-				|| RegOpenKeyExA(HKEY_LOCAL_MACHINE, REG_KEY_ROOT_INSTANCES, 0,
+				|| RegOpenKeyEx(HKEY_LOCAL_MACHINE, REG_KEY_ROOT_INSTANCES, 0,
 					KEY_READ | KEY_WOW64_64KEY, &hkey_instances) == ERROR_SUCCESS)
 			{
 				DWORD keytype;
@@ -172,14 +182,25 @@ FBCLIENT* FBCLIENT::Call()
 					&& keytype == REG_SZ)
 				{
 					int len = lstrlen(fbdll);
-					lstrcatA(fbdll, "bin\\fbclient.dll");
-					mHandle = LoadLibraryA(fbdll);
-					// try 32 bit client library of 64 bit server too
-					if (mHandle == 0)
-					{
-						lstrcpy(fbdll + len, "WOW64\\fbclient.dll");
-						mHandle = LoadLibraryA(fbdll);
-					}
+                    // for Firebird 3+
+                    lstrcat(fbdll, "fbclient.dll");
+                    mHandle = LoadLibrary(fbdll);
+                    // try 32 bit client library of 64 bit server too 
+                    if (mHandle == 0) {
+                        lstrcpy(fbdll + len, "WOW64\\fbclient.dll");
+                        mHandle = LoadLibrary(fbdll);
+                        // for Firebird 2.5 -
+                        if (mHandle == 0){
+                            lstrcpy(fbdll + len, "bin\\fbclient.dll");
+                            mHandle = LoadLibrary(fbdll);
+                            // try 32 bit client library of 64 bit server too
+                            if (mHandle == 0)
+                            {
+                                lstrcpy(fbdll + len, "WOW64\\fbclient.dll");
+                                mHandle = LoadLibrary(fbdll);
+                            }
+                        }
+                    }
 				}
 				RegCloseKey(hkey_instances);
 			}
@@ -188,12 +209,12 @@ FBCLIENT* FBCLIENT::Call()
 		if (mHandle == 0)
 		{
 			// Let's try from the PATH and System directories
-			mHandle = LoadLibraryA("fbclient.dll");
+			mHandle = LoadLibrary("fbclient.dll");
 			if (mHandle == 0)
 			{
 				// Not found. Last try : attemps loading gds32.dll from PATH and
 				// System directories
-				mHandle = LoadLibraryA("gds32.dll");
+				mHandle = LoadLibrary("gds32.dll");
 				if (mHandle == 0)
 					throw LogicExceptionImpl("GDS::Call()",
 						_("Can't find or load FBCLIENT.DLL or GDS32.DLL"));
@@ -336,8 +357,12 @@ namespace IBPP
 	Database DatabaseFactory(const std::string& ServerName,
 		const std::string& DatabaseName, const std::string& UserName,
 		const std::string& UserPassword, const std::string& RoleName,
-		const std::string& CharSet, const std::string& CreateParams)
+		const std::string& CharSet, const std::string& CreateParams,
+        const std::string& FBClient)
 	{
+        
+        if (FBClient.length() != 0)
+            gds.mfbdll = FBClient;
 		(void)gds.Call();			// Triggers the initialization, if needed
 		return new DatabaseImpl(ServerName, DatabaseName, UserName,
 								UserPassword, RoleName, CharSet, CreateParams);

--- a/src/ibpp/_ibpp.cpp
+++ b/src/ibpp/_ibpp.cpp
@@ -196,7 +196,7 @@ FBCLIENT* FBCLIENT::Call()
                             // try 32 bit client library of 64 bit server too
                             if (mHandle == 0)
                             {
-                                lstrcpy(fbdll + len, "WOW64\\fbclient.dll");
+                                lstrcpy(fbdll + len, "bin\\WOW64\\fbclient.dll");
                                 mHandle = LoadLibrary(fbdll);
                             }
                         }

--- a/src/ibpp/_ibpp.h
+++ b/src/ibpp/_ibpp.h
@@ -391,6 +391,7 @@ struct FBCLIENT
 {
     // Attributes
     bool mReady;
+    std::string mfbdll;
 
 #ifdef IBPP_WINDOWS
     HMODULE mHandle;            // The FBCLIENT.DLL HMODULE
@@ -764,6 +765,7 @@ public:
     ServiceImpl(const std::string& ServerName, const std::string& UserName,
                     const std::string& UserPassword);
     ~ServiceImpl();
+    FBCLIENT getGDS() const { return gds; };
 
     //  (((((((( OBJECT INTERFACE ))))))))
 
@@ -807,6 +809,8 @@ class DatabaseImpl : public IBPP::IDatabase
 {
     //  (((((((( OBJECT INTERNALS ))))))))
 
+    FBCLIENT gdsM;	// Local GDS instance
+
     int mRefCount;              // Reference counter
     isc_db_handle mHandle;      // InterBase API Session Handle
     std::string mServerName;    // Server name
@@ -844,6 +848,7 @@ public:
                 const std::string& RoleName, const std::string& CharSet,
                 const std::string& CreateParams);
     ~DatabaseImpl();
+    FBCLIENT getGDS() const { return gds; };
 
     //  (((((((( OBJECT INTERFACE ))))))))
 
@@ -916,6 +921,8 @@ public:
         IBPP::TIL il = IBPP::ilConcurrency,
         IBPP::TLR lr = IBPP::lrWait, IBPP::TFF flags = IBPP::TFF(0));
     ~TransactionImpl();
+
+    FBCLIENT getGDS() const { return gds; };
 
     //  (((((((( OBJECT INTERFACE ))))))))
 
@@ -1091,10 +1098,12 @@ public:
 
     StatementImpl(DatabaseImpl*, TransactionImpl*);
     ~StatementImpl();
+    FBCLIENT getGDS() const { return mDatabase->getGDS(); };
 
     //  (((((((( OBJECT INTERFACE ))))))))
 
 public:
+
     void Prepare(const std::string& sql);
     void Execute(const std::string& sql);
     inline void Execute()   { Execute(std::string()); }
@@ -1256,6 +1265,7 @@ public:
     BlobImpl(const BlobImpl&);
     BlobImpl(DatabaseImpl*, TransactionImpl* = 0);
     ~BlobImpl();
+    FBCLIENT getGDS() const { return mDatabase->getGDS(); };
 
     //  (((((((( OBJECT INTERFACE ))))))))
 
@@ -1312,6 +1322,7 @@ public:
     ArrayImpl(const ArrayImpl&);
     ArrayImpl(DatabaseImpl*, TransactionImpl* = 0);
     ~ArrayImpl();
+    FBCLIENT getGDS() const { return mDatabase->getGDS(); };
 
     //  (((((((( OBJECT INTERFACE ))))))))
 
@@ -1400,6 +1411,8 @@ public:
 
     EventsImpl(DatabaseImpl* dbi);
     ~EventsImpl();
+    FBCLIENT getGDS() const { return mDatabase->getGDS(); };
+
 
     //  (((((((( OBJECT INTERFACE ))))))))
 

--- a/src/ibpp/array.cpp
+++ b/src/ibpp/array.cpp
@@ -44,7 +44,7 @@ void ArrayImpl::Describe(const std::string& table, const std::string& column)
 	ResetId();	// Re-use this array object if was previously assigned
 
 	IBS status;
-	(*gds.Call()->m_array_lookup_bounds)(status.Self(), mDatabase->GetHandlePtr(),
+	(*getGDS().Call()->m_array_lookup_bounds)(status.Self(), mDatabase->GetHandlePtr(),
 		mTransaction->GetHandlePtr(), const_cast<char*>(table.c_str()),
 			const_cast<char*>(column.c_str()), &mDesc);
 	if (status.Errors())
@@ -194,7 +194,7 @@ void ArrayImpl::ReadTo(IBPP::ADT adtype, void* data, int datacount)
 
 	IBS status;
 	ISC_LONG lenbuf = mBufferSize;
-	(*gds.Call()->m_array_get_slice)(status.Self(), mDatabase->GetHandlePtr(),
+	(*getGDS().Call()->m_array_get_slice)(status.Self(), mDatabase->GetHandlePtr(),
 		mTransaction->GetHandlePtr(), &mId, &mDesc, mBuffer, &lenbuf);
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Array::ReadTo", _("isc_array_get_slice failed."));
@@ -879,7 +879,7 @@ void ArrayImpl::WriteFrom(IBPP::ADT adtype, const void* data, int datacount)
 
 	IBS status;
 	ISC_LONG lenbuf = mBufferSize;
-	(*gds.Call()->m_array_put_slice)(status.Self(), mDatabase->GetHandlePtr(),
+	(*getGDS().Call()->m_array_put_slice)(status.Self(), mDatabase->GetHandlePtr(),
 		mTransaction->GetHandlePtr(), &mId, &mDesc, mBuffer, &lenbuf);
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Array::WriteFrom", _("isc_array_put_slice failed."));

--- a/src/ibpp/blob.cpp
+++ b/src/ibpp/blob.cpp
@@ -42,7 +42,7 @@ void BlobImpl::Open()
 		throw LogicExceptionImpl("Blob::Open", _("Blob Id is not assigned."));
 
 	IBS status;
-	(*gds.Call()->m_open_blob2)(status.Self(), mDatabase->GetHandlePtr(),
+	(*getGDS().Call()->m_open_blob2)(status.Self(), mDatabase->GetHandlePtr(),
 		mTransaction->GetHandlePtr(), &mHandle, &mId, 0, 0);
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Blob::Open", _("isc_open_blob2 failed."));
@@ -59,7 +59,7 @@ void BlobImpl::Create()
 		throw LogicExceptionImpl("Blob::Create", _("No Transaction is attached."));
 
 	IBS status;
-	(*gds.Call()->m_create_blob2)(status.Self(), mDatabase->GetHandlePtr(),
+	(*getGDS().Call()->m_create_blob2)(status.Self(), mDatabase->GetHandlePtr(),
 		mTransaction->GetHandlePtr(), &mHandle, &mId, 0, 0);
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Blob::Create",
@@ -73,7 +73,7 @@ void BlobImpl::Close()
 	if (mHandle == 0) return;	// Not opened anyway
 
 	IBS status;
-	(*gds.Call()->m_close_blob)(status.Self(), &mHandle);
+	(*getGDS().Call()->m_close_blob)(status.Self(), &mHandle);
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Blob::Close", _("isc_close_blob failed."));
 	mHandle = 0;
@@ -87,7 +87,7 @@ void BlobImpl::Cancel()
 		throw LogicExceptionImpl("Blob::Cancel", _("Can't cancel a Blob opened for read"));
 
 	IBS status;
-	(*gds.Call()->m_cancel_blob)(status.Self(), &mHandle);
+	(*getGDS().Call()->m_cancel_blob)(status.Self(), &mHandle);
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Blob::Cancel", _("isc_cancel_blob failed."));
 	mHandle = 0;
@@ -105,7 +105,7 @@ int BlobImpl::Read(void* buffer, int size)
 
 	IBS status;
 	unsigned short bytesread;
-	ISC_STATUS result = (*gds.Call()->m_get_segment)(status.Self(), &mHandle, &bytesread,
+	ISC_STATUS result = (*getGDS().Call()->m_get_segment)(status.Self(), &mHandle, &bytesread,
 					(unsigned short)size, (char*)buffer);
 	if (result == isc_segstr_eof) return 0;	// Fin du blob
 	if (result != isc_segment && status.Errors())
@@ -123,7 +123,7 @@ void BlobImpl::Write(const void* buffer, int size)
 		throw LogicExceptionImpl("Blob::Write", _("Invalid segment size (max 64Kb-1)"));
 
 	IBS status;
-	(*gds.Call()->m_put_segment)(status.Self(), &mHandle,
+	(*getGDS().Call()->m_put_segment)(status.Self(), &mHandle,
 		(unsigned short)size, (char*)buffer);
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Blob::Write", _("isc_put_segment failed."));
@@ -140,7 +140,7 @@ void BlobImpl::Info(int* Size, int* Largest, int* Segments)
 
 	IBS status;
 	RB result(100);
-	(*gds.Call()->m_blob_info)(status.Self(), &mHandle, sizeof(items), items,
+	(*getGDS().Call()->m_blob_info)(status.Self(), &mHandle, sizeof(items), items,
 		(short)result.Size(), result.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Blob::GetInfo", _("isc_blob_info failed."));
@@ -160,7 +160,7 @@ void BlobImpl::Save(const std::string& data)
 		throw LogicExceptionImpl("Blob::Save", _("No Transaction is attached."));
 
 	IBS status;
-	(*gds.Call()->m_create_blob2)(status.Self(), mDatabase->GetHandlePtr(),
+	(*getGDS().Call()->m_create_blob2)(status.Self(), mDatabase->GetHandlePtr(),
 		mTransaction->GetHandlePtr(), &mHandle, &mId, 0, 0);
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Blob::Save",
@@ -174,7 +174,7 @@ void BlobImpl::Save(const std::string& data)
 	{
 		size_t blklen = (len < 32*1024-1) ? len : 32*1024-1;
 		status.Reset();
-		(*gds.Call()->m_put_segment)(status.Self(), &mHandle,
+		(*getGDS().Call()->m_put_segment)(status.Self(), &mHandle,
 			(unsigned short)blklen, const_cast<char*>(data.data()+pos));
 		if (status.Errors())
 			throw SQLExceptionImpl(status, "Blob::Save",
@@ -184,7 +184,7 @@ void BlobImpl::Save(const std::string& data)
 	}
 	
 	status.Reset();
-	(*gds.Call()->m_close_blob)(status.Self(), &mHandle);
+	(*getGDS().Call()->m_close_blob)(status.Self(), &mHandle);
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Blob::Save", _("isc_close_blob failed."));
 	mHandle = 0;
@@ -202,7 +202,7 @@ void BlobImpl::Load(std::string& data)
 		throw LogicExceptionImpl("Blob::Load", _("Blob Id is not assigned."));
 
 	IBS status;
-	(*gds.Call()->m_open_blob2)(status.Self(), mDatabase->GetHandlePtr(),
+	(*getGDS().Call()->m_open_blob2)(status.Self(), mDatabase->GetHandlePtr(),
 		mTransaction->GetHandlePtr(), &mHandle, &mId, 0, 0);
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Blob::Load", _("isc_open_blob2 failed."));
@@ -217,7 +217,7 @@ void BlobImpl::Load(std::string& data)
 	{
 		status.Reset();
 		unsigned short bytesread;
-		ISC_STATUS result = (*gds.Call()->m_get_segment)(status.Self(), &mHandle,
+		ISC_STATUS result = (*getGDS().Call()->m_get_segment)(status.Self(), &mHandle,
 						&bytesread, (unsigned short)blklen,
 							const_cast<char*>(data.data()+pos));
 		if (result == isc_segstr_eof) break;	// End of blob
@@ -231,7 +231,7 @@ void BlobImpl::Load(std::string& data)
 	data.resize(size);
 	
 	status.Reset();
-	(*gds.Call()->m_close_blob)(status.Self(), &mHandle);
+	(*getGDS().Call()->m_close_blob)(status.Self(), &mHandle);
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Blob::Load", _("isc_close_blob failed."));
 	mHandle = 0;

--- a/src/ibpp/database.cpp
+++ b/src/ibpp/database.cpp
@@ -56,7 +56,7 @@ void DatabaseImpl::Create(int dialect)
     // Call ExecuteImmediate to create the database
     isc_tr_handle tr_handle = 0;
     IBS status;
-    (*gds.Call()->m_dsql_execute_immediate)(status.Self(), &mHandle, &tr_handle,
+    (*getGDS().Call()->m_dsql_execute_immediate)(status.Self(), &mHandle, &tr_handle,
         0, const_cast<char*>(create.c_str()), short(dialect), NULL);
     if (status.Errors())
         throw SQLExceptionImpl(status, "Database::Create", _("isc_dsql_execute_immediate failed"));
@@ -89,7 +89,7 @@ void DatabaseImpl::Connect()
     connect.append(mDatabaseName);
 
     IBS status;
-    (*gds.Call()->m_attach_database)(status.Self(), (short)connect.size(),
+    (*getGDS().Call()->m_attach_database)(status.Self(), (short)connect.size(),
         const_cast<char*>(connect.c_str()), &mHandle, dpb.Size(), dpb.Self());
     if (status.Errors())
     {
@@ -108,12 +108,12 @@ void DatabaseImpl::Connect()
     RB result(100);
 
     status.Reset();
-    (*gds.Call()->m_database_info)(status.Self(), &mHandle, sizeof(items), items,
+    (*getGDS().Call()->m_database_info)(status.Self(), &mHandle, sizeof(items), items,
         result.Size(), result.Self());
     if (status.Errors())
     {
         status.Reset();
-        (*gds.Call()->m_detach_database)(status.Self(), &mHandle);
+        (*getGDS().Call()->m_detach_database)(status.Self(), &mHandle);
         mHandle = 0;     // Should be, but better be sure...
         throw SQLExceptionImpl(status, "Database::Connect", _("isc_database_info failed"));
     }
@@ -122,7 +122,7 @@ void DatabaseImpl::Connect()
     if (ODS <= 9)
     {
         status.Reset();
-        (*gds.Call()->m_detach_database)(status.Self(), &mHandle);
+        (*getGDS().Call()->m_detach_database)(status.Self(), &mHandle);
         mHandle = 0;     // Should be, but better be sure...
         throw LogicExceptionImpl("Database::Connect",
             _("Unsupported Server : wrong ODS version (%d), at least '10' required."), ODS);
@@ -132,7 +132,7 @@ void DatabaseImpl::Connect()
     if (mDialect != 1 && mDialect != 3)
     {
         status.Reset();
-        (*gds.Call()->m_detach_database)(status.Self(), &mHandle);
+        (*getGDS().Call()->m_detach_database)(status.Self(), &mHandle);
         mHandle = 0;     // Should be, but better be sure...
         throw LogicExceptionImpl("Database::Connect", _("Dialect 1 or 3 required"));
     }
@@ -185,7 +185,7 @@ void DatabaseImpl::Disconnect()
 
     // Detach from the server
     IBS status;
-    (*gds.Call()->m_detach_database)(status.Self(), &mHandle);
+    (*getGDS().Call()->m_detach_database)(status.Self(), &mHandle);
 
     // Should we throw, set mHandle to 0 first, because Disconnect() may
     // be called from Database destructor (keeps the object coherent).
@@ -203,7 +203,7 @@ void DatabaseImpl::Drop()
     Inactivate();
 
     IBS vector;
-    (*gds.Call()->m_drop_database)(vector.Self(), &mHandle);
+    (*getGDS().Call()->m_drop_database)(vector.Self(), &mHandle);
     if (vector.Errors())
         throw SQLExceptionImpl(vector, "Database::Drop", _("isc_drop_database failed"));
 
@@ -240,7 +240,7 @@ void DatabaseImpl::Info(int* ODSMajor, int* ODSMinor,
     RB result(256);
 
     status.Reset();
-    (*gds.Call()->m_database_info)(status.Self(), &mHandle, sizeof(items), items,
+    (*getGDS().Call()->m_database_info)(status.Self(), &mHandle, sizeof(items), items,
         result.Size(), result.Self());
     if (status.Errors())
         throw SQLExceptionImpl(status, "Database::Info", _("isc_database_info failed"));
@@ -274,7 +274,7 @@ void DatabaseImpl::TransactionInfo(int* Oldest, int* OldestActive,
     RB result(256);
 
     status.Reset();
-    (*gds.Call()->m_database_info)(status.Self(), &mHandle, sizeof(items), items,
+    (*getGDS().Call()->m_database_info)(status.Self(), &mHandle, sizeof(items), items,
         result.Size(), result.Self());
     if (status.Errors())
         throw SQLExceptionImpl(status, "Database::TransactionInfo", _("isc_database_info failed"));
@@ -304,7 +304,7 @@ void DatabaseImpl::Statistics(int* Fetches, int* Marks, int* Reads, int* Writes,
     RB result(256);
 
     status.Reset();
-    (*gds.Call()->m_database_info)(status.Self(), &mHandle, sizeof(items), items,
+    (*getGDS().Call()->m_database_info)(status.Self(), &mHandle, sizeof(items), items,
         result.Size(), result.Self());
     if (status.Errors())
         throw SQLExceptionImpl(status, "Database::Statistics", _("isc_database_info failed"));
@@ -332,7 +332,7 @@ void DatabaseImpl::Counts(int* Insert, int* Update, int* Delete,
     RB result(1024);
 
     status.Reset();
-    (*gds.Call()->m_database_info)(status.Self(), &mHandle, sizeof(items), items,
+    (*getGDS().Call()->m_database_info)(status.Self(), &mHandle, sizeof(items), items,
         result.Size(), result.Self());
     if (status.Errors())
         throw SQLExceptionImpl(status, "Database::Counts", _("isc_database_info failed"));
@@ -357,7 +357,7 @@ void DatabaseImpl::DetailedCounts(IBPP::DatabaseCounts& counts)
     RB result(1024);
 
     status.Reset();
-    (*gds.Call()->m_database_info)(status.Self(), &mHandle, sizeof(items), items,
+    (*getGDS().Call()->m_database_info)(status.Self(), &mHandle, sizeof(items), items,
         result.Size(), result.Self());
     if (status.Errors())
         throw SQLExceptionImpl(status, "Database::DetailedCounts", _("isc_database_info failed"));
@@ -378,7 +378,7 @@ void DatabaseImpl::Users(std::vector<std::string>& users)
     RB result(8000);
 
     status.Reset();
-    (*gds.Call()->m_database_info)(status.Self(), &mHandle, sizeof(items), items,
+    (*getGDS().Call()->m_database_info)(status.Self(), &mHandle, sizeof(items), items,
         result.Size(), result.Self());
     if (status.Errors())
         throw SQLExceptionImpl(status, "Database::Users", _("isc_database_info failed"));

--- a/src/ibpp/events.cpp
+++ b/src/ibpp/events.cpp
@@ -208,7 +208,7 @@ void EventsImpl::Queue()
 		IBS vector;
 		mTrapped = false;
 		mQueued = true;
-		(*gds.Call()->m_que_events)(vector.Self(), mDatabase->GetHandlePtr(), &mId,
+		(*getGDS().Call()->m_que_events)(vector.Self(), mDatabase->GetHandlePtr(), &mId,
 			short(mEventBuffer.size()), &mEventBuffer[0],
 				(isc_callback)EventHandler, (char*)this);
 
@@ -237,7 +237,7 @@ void EventsImpl::Cancel()
 		// subsequent to the execution of isc_cancel_events().
 		mTrapped = false;
 		mQueued = false;
-		(*gds.Call()->m_cancel_events)(vector.Self(), mDatabase->GetHandlePtr(), &mId);
+		(*getGDS().Call()->m_cancel_events)(vector.Self(), mDatabase->GetHandlePtr(), &mId);
 
 	    if (vector.Errors())
 		{

--- a/src/ibpp/ibpp.h
+++ b/src/ibpp/ibpp.h
@@ -978,7 +978,8 @@ public:
     //  }
 
     Service ServiceFactory(const std::string& ServerName,
-        const std::string& UserName, const std::string& UserPassword);
+        const std::string& UserName, const std::string& UserPassword,
+        const std::string& FBClient = "");
 
     Database DatabaseFactory(const std::string& ServerName,
         const std::string& DatabaseName, const std::string& UserName,

--- a/src/ibpp/ibpp.h
+++ b/src/ibpp/ibpp.h
@@ -983,12 +983,13 @@ public:
     Database DatabaseFactory(const std::string& ServerName,
         const std::string& DatabaseName, const std::string& UserName,
             const std::string& UserPassword, const std::string& RoleName,
-                const std::string& CharSet, const std::string& CreateParams);
+                const std::string& CharSet, const std::string& CreateParams,
+                    const std::string& FBClient = "");
 
     inline Database DatabaseFactory(const std::string& ServerName,
         const std::string& DatabaseName, const std::string& UserName,
-            const std::string& UserPassword)
-        { return DatabaseFactory(ServerName, DatabaseName, UserName, UserPassword, "", "", ""); }
+            const std::string& UserPassword, const std::string& FBClient = "")
+        { return DatabaseFactory(ServerName, DatabaseName, UserName, UserPassword, "", "", "", FBClient); }
 
     Transaction TransactionFactory(Database db, TAM am = amWrite,
         TIL il = ilConcurrency, TLR lr = lrWait, TFF flags = TFF(0));

--- a/src/ibpp/service.cpp
+++ b/src/ibpp/service.cpp
@@ -64,7 +64,7 @@ void ServiceImpl::Connect()
 
 	connect += "service_mgr";
 
-	(*gds.Call()->m_service_attach)(status.Self(), (short)connect.size(), (char*)connect.c_str(),
+	(*getGDS().Call()->m_service_attach)(status.Self(), (short)connect.size(), (char*)connect.c_str(),
 		&mHandle, spb.Size(), spb.Self());
 	if (status.Errors())
 	{
@@ -80,7 +80,7 @@ void ServiceImpl::Disconnect()
 	IBS status;
 
 	// Detach from the service manager
-	(*gds.Call()->m_service_detach)(status.Self(), &mHandle);
+	(*getGDS().Call()->m_service_detach)(status.Self(), &mHandle);
 
 	// Set mHandle to 0 now, just in case we need to throw, because Disconnect()
 	// is called from Service destructor and we want to maintain a coherent state.
@@ -102,7 +102,7 @@ void ServiceImpl::GetVersion(std::string& version)
 
 	spb.Insert(isc_info_svc_server_version);
 
-	(*gds.Call()->m_service_query)(status.Self(), &mHandle, 0, 0, 0, spb.Size(), spb.Self(),
+	(*getGDS().Call()->m_service_query)(status.Self(), &mHandle, 0, 0, 0, spb.Size(), spb.Self(),
 		result.Size(), result.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::GetVersion", _("isc_service_query failed"));
@@ -135,7 +135,7 @@ void ServiceImpl::AddUser(const IBPP::User& user)
 	if (user.groupid != 0)
 			spb.InsertQuad(isc_spb_sec_groupid, (int32_t)user.groupid);
 
-	(*gds.Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
+	(*getGDS().Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::AddUser", _("isc_service_start failed"));
 
@@ -167,7 +167,7 @@ void ServiceImpl::ModifyUser(const IBPP::User& user)
 	if (user.groupid != 0)
 			spb.InsertQuad(isc_spb_sec_groupid, (int32_t)user.groupid);
 
-	(*gds.Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
+	(*getGDS().Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::ModifyUser", _("isc_service_start failed"));
 
@@ -188,7 +188,7 @@ void ServiceImpl::RemoveUser(const std::string& username)
 	spb.Insert(isc_action_svc_delete_user);
 	spb.InsertString(isc_spb_sec_username, 2, username.c_str());
 
-	(*gds.Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
+	(*getGDS().Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::RemoveUser", _("isc_service_start failed"));
 
@@ -207,14 +207,14 @@ void ServiceImpl::GetUser(IBPP::User& user)
 	spb.InsertString(isc_spb_sec_username, 2, user.username.c_str());
 
 	IBS status;
-	(*gds.Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
+	(*getGDS().Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::GetUser", _("isc_service_start failed"));
 
 	RB result(8000);
 	char request[] = {isc_info_svc_get_users};
 	status.Reset();
-	(*gds.Call()->m_service_query)(status.Self(), &mHandle, 0, 0, 0,
+	(*getGDS().Call()->m_service_query)(status.Self(), &mHandle, 0, 0, 0,
 		sizeof(request), request, result.Size(), result.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::GetUser", _("isc_service_query failed"));
@@ -229,17 +229,17 @@ void ServiceImpl::GetUser(IBPP::User& user)
 	{
 		if (*p == isc_spb_sec_userid)
 		{
-			user.userid = (uint32_t)(*gds.Call()->m_vax_integer)(p+1, 4);
+			user.userid = (uint32_t)(*getGDS().Call()->m_vax_integer)(p+1, 4);
 			p += 5;
 		}
 		else if (*p == isc_spb_sec_groupid)
 		{
-			user.groupid = (uint32_t)(*gds.Call()->m_vax_integer)(p+1, 4);
+			user.groupid = (uint32_t)(*getGDS().Call()->m_vax_integer)(p+1, 4);
 			p += 5;
 		}
 		else
 		{
-			unsigned short len = (unsigned short)(*gds.Call()->m_vax_integer)(p+1, 2);
+			unsigned short len = (unsigned short)(*getGDS().Call()->m_vax_integer)(p+1, 2);
 			switch (*p)
 			{
 			case isc_spb_sec_username :
@@ -273,14 +273,14 @@ void ServiceImpl::GetUsers(std::vector<IBPP::User>& users)
 	spb.Insert(isc_action_svc_display_user);
 
 	IBS status;
-	(*gds.Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
+	(*getGDS().Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::GetUsers", _("isc_service_start failed"));
 
 	RB result(0xFFFF);
 	char request[] = {isc_info_svc_get_users};
 	status.Reset();
-	(*gds.Call()->m_service_query)(status.Self(), &mHandle, 0, 0, 0,
+	(*getGDS().Call()->m_service_query)(status.Self(), &mHandle, 0, 0, 0,
 		sizeof(request), request, result.Size(), result.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::GetUsers", _("isc_service_query failed"));
@@ -290,24 +290,24 @@ void ServiceImpl::GetUsers(std::vector<IBPP::User>& users)
 	if (*p != isc_info_svc_get_users)
 		throw SQLExceptionImpl(status, "Service::GetUsers", _("isc_service_query returned unexpected answer"));
 
-	char* pEnd = p + (unsigned short)(*gds.Call()->m_vax_integer)(p+1, 2);
+	char* pEnd = p + (unsigned short)(*getGDS().Call()->m_vax_integer)(p+1, 2);
 	p += 3;	// Skips the 'isc_info_svc_get_users' and its total length
 	IBPP::User user;
 	while (p < pEnd && *p != isc_info_end)
 	{
 		if (*p == isc_spb_sec_userid)
 		{
-			user.userid = (uint32_t)(*gds.Call()->m_vax_integer)(p+1, 4);
+			user.userid = (uint32_t)(*getGDS().Call()->m_vax_integer)(p+1, 4);
 			p += 5;
 		}
 		else if (*p == isc_spb_sec_groupid)
 		{
-			user.groupid = (uint32_t)(*gds.Call()->m_vax_integer)(p+1, 4);
+			user.groupid = (uint32_t)(*getGDS().Call()->m_vax_integer)(p+1, 4);
 			p += 5;
 		}
 		else
 		{
-			unsigned short len = (unsigned short)(*gds.Call()->m_vax_integer)(p+1, 2);
+			unsigned short len = (unsigned short)(*getGDS().Call()->m_vax_integer)(p+1, 2);
 			switch (*p)
 			{
 			case isc_spb_sec_username :
@@ -349,7 +349,7 @@ void ServiceImpl::SetPageBuffers(const std::string& dbfile, int buffers)
 	spb.InsertString(isc_spb_dbname, 2, dbfile.c_str());
 	spb.InsertQuad(isc_spb_prp_page_buffers, buffers);
 
-	(*gds.Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
+	(*getGDS().Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::SetPageBuffers", _("isc_service_start failed"));
 
@@ -370,7 +370,7 @@ void ServiceImpl::SetSweepInterval(const std::string& dbfile, int sweep)
 	spb.InsertString(isc_spb_dbname, 2, dbfile.c_str());
 	spb.InsertQuad(isc_spb_prp_sweep_interval, sweep);
 
-	(*gds.Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
+	(*getGDS().Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::SetSweepInterval", _("isc_service_start failed"));
 
@@ -392,7 +392,7 @@ void ServiceImpl::SetSyncWrite(const std::string& dbfile, bool sync)
 	if (sync) spb.InsertByte(isc_spb_prp_write_mode, (char)isc_spb_prp_wm_sync);
 	else spb.InsertByte(isc_spb_prp_write_mode, (char)isc_spb_prp_wm_async);
 
-	(*gds.Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
+	(*getGDS().Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::SetSyncWrite", _("isc_service_start failed"));
 
@@ -414,7 +414,7 @@ void ServiceImpl::SetReadOnly(const std::string& dbfile, bool readonly)
 	if (readonly) spb.InsertByte(isc_spb_prp_access_mode, (char)isc_spb_prp_am_readonly);
 	else spb.InsertByte(isc_spb_prp_access_mode, (char)isc_spb_prp_am_readwrite);
 
-	(*gds.Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
+	(*getGDS().Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::SetReadOnly", _("isc_service_start failed"));
 
@@ -436,7 +436,7 @@ void ServiceImpl::SetReserveSpace(const std::string& dbfile, bool reserve)
 	if (reserve) spb.InsertByte(isc_spb_prp_reserve_space, (char)isc_spb_prp_res);
 	else spb.InsertByte(isc_spb_prp_reserve_space, (char)isc_spb_prp_res_use_full);
 
-	(*gds.Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
+	(*getGDS().Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::SetReserveSpace", _("isc_service_start failed"));
 
@@ -468,7 +468,7 @@ void ServiceImpl::Shutdown(const std::string& dbfile, IBPP::DSM mode, int sectim
 			break;
 	}
 
-	(*gds.Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
+	(*getGDS().Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::Shutdown", _("isc_service_start failed"));
 
@@ -489,7 +489,7 @@ void ServiceImpl::Restart(const std::string& dbfile)
 	spb.InsertString(isc_spb_dbname, 2, dbfile.c_str());
 	spb.InsertQuad(isc_spb_options, isc_spb_prp_db_online);
 
-	(*gds.Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
+	(*getGDS().Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::Restart", _("isc_service_start failed"));
 
@@ -510,7 +510,7 @@ void ServiceImpl::Sweep(const std::string& dbfile)
 	spb.InsertString(isc_spb_dbname, 2, dbfile.c_str());
 	spb.InsertQuad(isc_spb_options, isc_spb_rpr_sweep_db);
 
-	(*gds.Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
+	(*getGDS().Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::Sweep", _("isc_service_start failed"));
 
@@ -543,7 +543,7 @@ void ServiceImpl::Repair(const std::string& dbfile, IBPP::RPF flags)
 	
 	spb.InsertQuad(isc_spb_options, mask);
 
-	(*gds.Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
+	(*getGDS().Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::Repair", _("isc_service_start failed"));
 
@@ -577,7 +577,7 @@ void ServiceImpl::StartBackup(const std::string& dbfile,
 	if (flags & IBPP::brConvertExtTables)	mask |= isc_spb_bkp_convert;
 	if (mask != 0) spb.InsertQuad(isc_spb_options, mask);
 
-	(*gds.Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
+	(*getGDS().Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::Backup", _("isc_service_start failed"));
 }
@@ -612,7 +612,7 @@ void ServiceImpl::StartRestore(const std::string& bkfile, const std::string& dbf
 	if (flags & IBPP::brUseAllSpace)	mask |= isc_spb_res_use_all_space;
 	if (mask != 0) spb.InsertQuad(isc_spb_options, mask);
 
-	(*gds.Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
+	(*getGDS().Call()->m_service_start)(status.Self(), &mHandle, 0, spb.Size(), spb.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "Service::Restore", _("isc_service_start failed"));
 }
@@ -627,7 +627,7 @@ const char* ServiceImpl::WaitMsg()
 
 	// _service_query will only block until a line of result is available
 	// (or until the end of the task if it does not report information)
-	(*gds.Call()->m_service_query)(status.Self(), &mHandle, 0, 0, 0,
+	(*getGDS().Call()->m_service_query)(status.Self(), &mHandle, 0, 0, 0,
 		req.Size(),	req.Self(),	result.Size(), result.Self());
 	if (status.Errors())
 		throw SQLExceptionImpl(status, "ServiceImpl::Wait", _("isc_service_query failed"));
@@ -659,7 +659,7 @@ void ServiceImpl::Wait()
 
 		// _service_query will only block until a line of result is available
 		// (or until the end of the task if it does not report information) 
-		(*gds.Call()->m_service_query)(status.Self(), &mHandle, 0, 0,	0,
+		(*getGDS().Call()->m_service_query)(status.Self(), &mHandle, 0, 0,	0,
 			spb.Size(),	spb.Self(),	result.Size(), result.Self());
 		if (status.Errors())
 			throw SQLExceptionImpl(status, "ServiceImpl::Wait", _("isc_service_query failed"));

--- a/src/ibpp/transaction.cpp
+++ b/src/ibpp/transaction.cpp
@@ -132,7 +132,7 @@ void TransactionImpl::Start()
     }
 
     IBS status;
-    (*gds.Call()->m_start_multiple)(status.Self(), &mHandle, (short)mDatabases.size(), teb);
+    (*getGDS().Call()->m_start_multiple)(status.Self(), &mHandle, (short)mDatabases.size(), teb);
     delete [] teb;
     if (status.Errors())
     {
@@ -148,7 +148,7 @@ void TransactionImpl::Commit()
 
     IBS status;
 
-    (*gds.Call()->m_commit_transaction)(status.Self(), &mHandle);
+    (*getGDS().Call()->m_commit_transaction)(status.Self(), &mHandle);
     if (status.Errors())
         throw SQLExceptionImpl(status, "Transaction::Commit");
     mHandle = 0;    // Should be, better be sure
@@ -167,7 +167,7 @@ void TransactionImpl::CommitRetain()
 
     IBS status;
 
-    (*gds.Call()->m_commit_retaining)(status.Self(), &mHandle);
+    (*getGDS().Call()->m_commit_retaining)(status.Self(), &mHandle);
     if (status.Errors())
         throw SQLExceptionImpl(status, "Transaction::CommitRetain");
 }
@@ -178,7 +178,7 @@ void TransactionImpl::Rollback()
 
     IBS status;
 
-    (*gds.Call()->m_rollback_transaction)(status.Self(), &mHandle);
+    (*getGDS().Call()->m_rollback_transaction)(status.Self(), &mHandle);
     if (status.Errors())
         throw SQLExceptionImpl(status, "Transaction::Rollback");
     mHandle = 0;    // Should be, better be sure
@@ -197,7 +197,7 @@ void TransactionImpl::RollbackRetain()
 
     IBS status;
 
-    (*gds.Call()->m_rollback_retaining)(status.Self(), &mHandle);
+    (*getGDS().Call()->m_rollback_retaining)(status.Self(), &mHandle);
     if (status.Errors())
         throw SQLExceptionImpl(status, "Transaction::RollbackRetain");
 }

--- a/src/metadata/database.cpp
+++ b/src/metadata/database.cpp
@@ -1725,7 +1725,10 @@ wxString Database::getPath() const
 
 wxString Database::getClientLibrary() const
 {
-    return clientLibraryM;
+    /*Todo: Implement FB library per conexion */
+    //return clientLibraryM;
+    wxString LValue = "";
+    return config().get("LibraryFile", LValue);
 }
 
 int Database::getSqlDialect() const

--- a/src/metadata/database.cpp
+++ b/src/metadata/database.cpp
@@ -1024,7 +1024,9 @@ void Database::create(int pagesize, int dialect)
         wx2std(getConnectionString()),
         (useUserNamePwd ? wx2std(getUsername()) : ""),
         (useUserNamePwd ? wx2std(getDecryptedPassword()) : ""),
-        "", wx2std(charset), wx2std(extra_params));
+        "", wx2std(charset), wx2std(extra_params),
+        wx2std(getClientLibrary())
+    );
     db->Create(dialect);
 }
 
@@ -1069,7 +1071,9 @@ void Database::connect(const wxString& password, ProgressIndicator* indicator)
                 wx2std(getConnectionString()),
                 (useUserNamePwd ? wx2std(getUsername()) : ""),
                 (useUserNamePwd ? wx2std(password) : ""),
-                wx2std(getRole()), wx2std(getConnectionCharset()), "");
+                wx2std(getRole()), wx2std(getConnectionCharset()), 
+                "", wx2std(getClientLibrary())
+            );
             db->Connect();  // As standard, will block for 180 seconds or until connected
             return db;
         };
@@ -1719,6 +1723,11 @@ wxString Database::getPath() const
     return pathM;
 }
 
+wxString Database::getClientLibrary() const
+{
+    return clientLibraryM;
+}
+
 int Database::getSqlDialect() const
 {
     return dialectM;
@@ -1820,6 +1829,11 @@ IBPP::Database& Database::getIBPPDatabase()
 void Database::setPath(const wxString& value)
 {
     pathM = value;
+}
+
+void Database::setClientLibrary(const wxString& value)
+{
+    clientLibraryM = value;
 }
 
 void Database::setConnectionCharset(const wxString& value)

--- a/src/metadata/database.h
+++ b/src/metadata/database.h
@@ -170,6 +170,7 @@ private:
     wxString sqlSecurityM; // ODS 13
 
     wxString pathM;
+    wxString clientLibraryM;
     int dialectM;
     Credentials credentialsM;
     Credentials* connectionCredentialsM;
@@ -312,6 +313,7 @@ public:
     void getDatabaseTriggers(std::vector<Trigger *>& list);
 
     wxString getPath() const;
+    wxString getClientLibrary() const;
     int getSqlDialect() const;
     wxString getDatabaseCharset() const;
     wxString getConnectionCharset() const;
@@ -324,6 +326,7 @@ public:
     wxString getRole() const;
     IBPP::Database& getIBPPDatabase();
     void setPath(const wxString& value);
+    void setClientLibrary(const wxString& value);
     void setConnectionCharset(const wxString& value);
     void setUsername(const wxString& value);
     void setRawPassword(const wxString& value);

--- a/src/metadata/domain.cpp
+++ b/src/metadata/domain.cpp
@@ -66,7 +66,7 @@ std::string Domain::getLoadStatement(bool list)
             " on l.rdb$collation_id = f.rdb$collation_id"
             " and l.rdb$character_set_id = f.rdb$character_set_id"
         " left outer join rdb$types t on f.rdb$field_type=t.rdb$type"
-        " where t.rdb$field_name='RDB$FIELD_TYPE' and f.rdb$field_name ");
+        " where trim(t.rdb$field_name)='RDB$FIELD_TYPE' and f.rdb$field_name ");
 	if (list) {
 		stmt += "not starting with 'RDB$' ";
 		//if (db->getInfo().getODSVersionIsHigherOrEqualTo(12, 0)) //If Firebird 3 ODS, remove SEC$DOMAINs, this is a static method, so I wont be able to get ODS

--- a/src/metadata/function.cpp
+++ b/src/metadata/function.cpp
@@ -618,7 +618,7 @@ wxString FunctionSQL::getAlterSql(bool full)
 		if (!output.empty())
 			sql += output ;
 	}
-	sql += getSqlSecurity() + "\n";
+    sql += +"\n" + getSqlSecurity() + "\n";
 	if (full)
 		sql += getSource();
 	else

--- a/src/metadata/procedure.cpp
+++ b/src/metadata/procedure.cpp
@@ -429,7 +429,7 @@ wxString Procedure::getAlterSql(bool full)
         if (!output.empty())
             sql += output + " )";
     }
-    sql += getSqlSecurity() + "\n";
+    sql += +"\n" + getSqlSecurity() + "\n";
     if (full)
         sql += getSource();
     else

--- a/src/metadata/root.cpp
+++ b/src/metadata/root.cpp
@@ -158,6 +158,8 @@ bool Root::parseDatabase(ServerPtr server, wxXmlNode* xmln)
             if (value.ToULong(&id))
                 database->setId(id);
         }
+        else if (xmln->GetName() == "fbclient")
+            database->setClientLibrary(value);
     }
 
     // make sure the database has an Id before Root::save() is called,
@@ -309,6 +311,7 @@ bool Root::save()
             rsAddChildNode(dbn, "username", (*itdb)->getUsername());
             rsAddChildNode(dbn, "password", (*itdb)->getRawPassword());
             rsAddChildNode(dbn, "role", (*itdb)->getRole());
+            rsAddChildNode(dbn, "fbclient", (*itdb)->getClientLibrary());
             rsAddChildNode(dbn, "authentication",
                 (*itdb)->getAuthenticationMode().getConfigValue());
         }


### PR DESCRIPTION
Added configuration for FB client library.

![imagen](https://user-images.githubusercontent.com/11672188/174469267-05fdca77-70f2-4c32-ad8d-68e7d32df847.png)

**At the moment the configuration applies only to windows and at the application level.** Connection level implementation pending.
The search order of the library is corrected, remaining as follows:

1. Try specific library, according to the FR configuration.
2. Try to load fbembed.dll from the current application location.
3.  Try to load fbclient.dll from the current application location.
4. Try to locate fbclient.dll through the installation registry. It only looks for "DefaultInstance"; If your installation has another name, this is not taken into account.
4.1. Try to locate %FB Directory%\fbclient.dll
4.2.- Try to locate %FB Directory%\wow64\fbclient.dll
4.3.- Try to locate %FB Directory%\bin\fbclient.dll
4.4.- Try to locate %FB Directory%\bin\wow64\fbclient.dll



5.- Let's try from the PATH and System directories for FBClient.dll
6.- Last try : attemps loading gds32.dll from PATH and System directories

Fix: #199 #229 #251 #258 