### PR TITLE
small typo in databasehandler.cpp

### DIFF
--- a/src/databasehandler.cpp
+++ b/src/databasehandler.cpp
@@ -131,7 +131,7 @@ bool DatabaseInfoHandler::handleURI(URI& uri)
             else if (isEditPageBuffers)
                 svc->SetPageBuffers(wx2std(d->getPath()), value);
             else if (isEditLinger)
-                execSql(NULL, wxString(_("Alter databse")), d, wxString::Format("ALTER DATABASE SET LINGER TO %d ; commit; ", value, w), true);
+                execSql(NULL, wxString(_("Alter database")), d, wxString::Format("ALTER DATABASE SET LINGER TO %d ; commit; ", value, w), true);
             // Before reloading the info, re-attach to the database
             // otherwise the sweep interval won't be changed for FB Classic
             // Server.


### PR DESCRIPTION

In Debian we are currently applying the following patch to
flamerobin.
We thought you might be interested in it too.

    Description: small typo in databasehandler.cpp
     databse â database
    Author: Damyan Ivanov <dmn@debian.org>

The patch is tracked in our Git repository at
https://salsa.debian.org/debian/flamerobin/raw/master/debian/patches/out/spelling.patch

Thanks for considering,
  Damyan Ivanov,
