### PR TITLE
Int128 fixes on 32-bit arm and other non-mainstream architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,18 @@ if (UNIX AND NOT APPLE)
 	# Need to link the fbclient lib in *nix systems
 	list(APPEND FR_LIBS -lfbclient)
 
+	include(CheckCXXSourceCompiles)
+	check_cxx_source_compiles("
+int main() {
+    __int128 x;
+    return 0;
+}
+" HAVE_INT128)
+
+	if (HAVE_INT128)
+		add_definitions(-DHAVE_INT128)
+	endif()
+
 	# Create the revision include file
 	execute_process(
 		COMMAND "${CMAKE_SOURCE_DIR}/update-revision-info.sh"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,6 +374,18 @@ int main() {
 		add_definitions(-DHAVE_INT128)
 	endif()
 
+	check_cxx_source_compiles("
+#include <decimal/decimal>
+int main() {
+    std::decimal::decimal128 x;
+    return 0;
+}
+" HAVE_DECIMAL128)
+
+	if (HAVE_DECIMAL128)
+		add_definitions(-DHAVE_DECIMAL128)
+	endif()
+
 	# Create the revision include file
 	execute_process(
 		COMMAND "${CMAKE_SOURCE_DIR}/update-revision-info.sh"

--- a/src/core/FRDecimal.cpp
+++ b/src/core/FRDecimal.cpp
@@ -43,7 +43,7 @@ typedef union _DECFLOAT128_UNION
     struct
     {
         // if higher bits of comb 00/01/10
-#ifdef _MSC_VER
+#ifndef HAVE_INT128
         uint64_t declet0 : 10;
         uint64_t declet1 : 10;
         uint64_t declet2 : 10;
@@ -81,7 +81,7 @@ typedef union _DECFLOAT128_UNION
     struct
     {
         // if higher bits of comb 11
-#ifdef _MSC_VER
+#ifndef HAVE_INT128
         uint64_t declet0 : 10;
         uint64_t declet1 : 10;
         uint64_t declet2 : 10;
@@ -121,7 +121,7 @@ typedef union _DECFLOAT128_UNION
     struct
     {
         // comb = 1111 infinite (1111) / NaN (
-#ifdef _MSC_VER
+#ifndef HAVE_INT128
         uint64_t unused1 : 64;
         uint64_t unused2 : 58;
         uint64_t nantype : 1; // 0 quiet / 1 signalling
@@ -369,7 +369,7 @@ void Dec34DPDToDecInfo(const dec34_t src, DECFLOAT_DECINFO* info)
     AppendDecletToStr(dfu.dpd1.declet9, mantStr);
     AppendDecletToStr(dfu.dpd1.declet8, mantStr);
     AppendDecletToStr(dfu.dpd1.declet7, mantStr);
-#ifdef _MSC_VER
+#ifndef HAVE_INT128
     AppendDecletToStr(dfu.dpd1.declet6a || dfu.dpd1.declet6b << 4, mantStr);
 #else
     AppendDecletToStr(dfu.dpd1.declet6, mantStr);
@@ -750,7 +750,7 @@ bool DecInfoToDec34DPD(const DECFLOAT_DECINFO &info, dec34_t* dst)
     dfu.dpd1.declet3 = Str3ToDeclet(info.mantStr, mantOfs);
     dfu.dpd1.declet4 = Str3ToDeclet(info.mantStr, mantOfs);
     dfu.dpd1.declet5 = Str3ToDeclet(info.mantStr, mantOfs);
-#ifdef _MSC_VER
+#ifndef HAVE_INT128
     uint32_t declet6 = Str3ToDeclet(info.mantStr, mantOfs);
     dfu.dpd1.declet6a = declet6 & 0xf;
     dfu.dpd1.declet6b = (declet6 & 0x3f) >> 4; 

--- a/src/ibpp/ibpp.h
+++ b/src/ibpp/ibpp.h
@@ -67,7 +67,7 @@
 #include <string>
 #include <vector>
 
-#ifndef _MSC_VER
+#ifdef HAVE_DECIMAL128
 #include <decimal/decimal>
 #endif
 
@@ -161,17 +161,6 @@ namespace IBPP
     // int128 - FB4
     #pragma pack(push, 1)
 
-    // gcc has a builtin type __int128
-    // msvc does not have something we can use (AFICS)
-    // so we have to do it by own code.
-    #define HAVE_INT128
-    #define HAVE_DECFLOAT
-
-    #ifdef _MSC_VER
-    #undef HAVE_INT128
-    #undef HAVE_DECFLOAT
-    #endif
-
     #ifndef HAVE_INT128
     // NOTICE: could/should be replaced with int128_t if msvc supports this
     typedef struct IBPP_INT128_T
@@ -225,7 +214,7 @@ public:
     typedef __uint128_t ibpp_uint128_t;
     #endif
 
-    #ifndef HAVE_DECFLOAT
+    #ifndef HAVE_DECIMAL128
     typedef struct IBPP_DEC16_T
     {
         int64_t lowPart;


### PR DESCRIPTION
Currently the availability of __int128 and std::decimal::decimalXXX is determined via checkd for compiler type. GCC is assumed to have them, and MSVC is assumed to miss them. However, gcc misses them on 32-bit arm, mips and other more "exotic" architectures.

The proposed solution tests the availability of __int128 and std::decimal::decimal128 via CMakeFiles.txt and adds -D defined to the compiler command line of they are available. Further, the code that uses them is made conditional on these defines, instead of on compiler type.

The result builds on all Debian architectures where wx3.2 is available (14 architectures): https://buildd.debian.org/status/package.php?p=flamerobin