### PR TITLE
Bug fixed (Build-on : GNU/Linux) -> target_file: PreferencesDialogStyle.cpp, target_line: 571

### DIFF
--- a/src/gui/PreferencesDialogStyle.cpp
+++ b/src/gui/PreferencesDialogStyle.cpp
@@ -568,8 +568,7 @@ void PrefDlgStyleSetting::saveStyle(const wxString& styleName)
     int i = fontNameComboBoxM->GetSelection();
     if (i>0)
         style->setFontName(fontNameComboBoxM->GetString(fontNameComboBoxM->GetSelection()));
-    style->setFontSize(atoi(fontSizeComboBoxM->GetString(fontSizeComboBoxM->GetSelection())));
-
+    style->setFontSize(atoi(fontSizeComboBoxM->GetString(fontSizeComboBoxM->GetSelection()).ToStdString().c_str()));
 
     style->setfgColor(foregroundPickerM->GetColour());
     style->setbgColor(backgroundPickerM->GetColour());


### PR DESCRIPTION
Hi !

Here a bug : 

![bug_flamerobin_0 9 12](https://github.com/user-attachments/assets/9d57dec0-c0a7-4c0d-876e-5d3163eca6d2)


**I fixed it** by modifying this file PreferencesDialogStyle.cpp, the affected line is (line 571) :
```style->setFontSize(atoi(fontSizeComboBoxM->GetString(fontSizeComboBoxM->GetSelection())));```

**Here the update** :

```style->setFontSize(atoi(fontSizeComboBoxM->GetString(fontSizeComboBoxM->GetSelection()).ToStdString().c_str()));```

<br />

Build-on : GNU/Linux

```
wx-config --version
3.2.6
```
