### PR TITLE
Implement shortcut for toggling line/block comments in SQL editor

### DIFF
--- a/src/gui/ExecuteSqlFrame.h
+++ b/src/gui/ExecuteSqlFrame.h
@@ -138,6 +138,7 @@ private:
     bool commitTransaction();
     bool rollbackTransaction();
 
+    void toggleBlockComment();
     void highlightOccurrences(const wxString& word);
     void OnTextSelected(wxStyledTextEvent& event);
     void autoComplete(bool force);


### PR DESCRIPTION
- Implemented support for the "Ctrl+/" shortcut to toggle block comments in the SQL editor.
- Added logic to handle both standard "/" and numeric keypad "/" keys. Resolves: #433