### PR TITLE
Remove trace-level output in ibpp/stamenet.cpp.

### DIFF
--- a/src/ibpp/statement.cpp
+++ b/src/ibpp/statement.cpp
@@ -856,7 +856,7 @@ std::string StatementImpl::ParametersParser(std::string sql)
         }
         debugProcessedSQL = sProcessedSQL.str();
     }
-  std::cout << "sProcessedSQL: " << sProcessedSQL.str() << std::endl;
+  //std::cout << "sProcessedSQL: " << sProcessedSQL.str() << std::endl;
 
   return sProcessedSQL.str();
 }


### PR DESCRIPTION
The output of `sProcessedSQL` to `std::cout` seems to be a remnant of some debugging session.