### PR TITLE
Fix ODS version checks: use major/minor args instead of float literals

### DIFF
--- a/src/gui/FieldPropertiesDialog.cpp
+++ b/src/gui/FieldPropertiesDialog.cpp
@@ -141,7 +141,7 @@ void FieldPropertiesDialog::createControls()
     checkbox_notnull = new wxCheckBox(getControlsPanel(), wxID_ANY, _("Not null"));
     {
         DatabasePtr db = tableM->getDatabase();
-        if (db->getInfo().getODSVersionIsHigherOrEqualTo(12.0)) {
+        if (db->getInfo().getODSVersionIsHigherOrEqualTo(12, 0)) {
             checkbox_identity = new wxCheckBox(getControlsPanel(), ID_checkbox_identity, _("Identity"));
             label_initialValue = new wxStaticText(getControlsPanel(), wxID_ANY, _("Initial Value:"));
             textctrl_initialValue = new wxTextCtrl(getControlsPanel(), wxID_ANY, wxEmptyString);
@@ -214,7 +214,7 @@ void FieldPropertiesDialog::layoutControls()
         wxALIGN_CENTER_VERTICAL | wxEXPAND);
     {
         DatabasePtr db = tableM->getDatabase();
-        if (db->getInfo().getODSVersionIsHigherOrEqualTo(12.0)) {
+        if (db->getInfo().getODSVersionIsHigherOrEqualTo(12, 0)) {
             sizerTop->Add(checkbox_identity, wxGBPosition(4, 0), wxDefaultSpan,
                 wxALIGN_CENTER_VERTICAL | wxEXPAND);
             sizerTop->Add(label_initialValue, wxGBPosition(4, 2), wxDefaultSpan,
@@ -354,8 +354,8 @@ bool FieldPropertiesDialog::getStatementsToExecute(wxString& statements,
     wxString dtSize = textctrl_size->GetValue();
     wxString dtScale = textctrl_scale->GetValue();
     bool isNullable = !checkbox_notnull->IsChecked();
-    bool isIdentity = tableM->getDatabase()->getInfo().getODSVersionIsHigherOrEqualTo(12.0) ? checkbox_identity->IsChecked() : false;
-    wxString initialValue = tableM->getDatabase()->getInfo().getODSVersionIsHigherOrEqualTo(12.0) ? textctrl_initialValue->GetValue() : "";
+    bool isIdentity = tableM->getDatabase()->getInfo().getODSVersionIsHigherOrEqualTo(12, 0) ? checkbox_identity->IsChecked() : false;
+    wxString initialValue = tableM->getDatabase()->getInfo().getODSVersionIsHigherOrEqualTo(12, 0) ? textctrl_initialValue->GetValue() : "";
 
     int n = choice_datatype->GetSelection();
     if (n >= 0 && n < datatypescnt)
@@ -660,7 +660,7 @@ void FieldPropertiesDialog::updateColumnControls()
         loadCollations();
         choice_collate->SetSelection(
             choice_collate->FindString(columnM->getCollation()));
-        if (tableM->getDatabase()->getInfo().getODSVersionIsHigherOrEqualTo(12.0)) {
+        if (tableM->getDatabase()->getInfo().getODSVersionIsHigherOrEqualTo(12, 0)) {
             checkbox_identity->SetValue(columnM->isIdentity());
             if (columnM->isIdentity()) {
                 textctrl_initialValue->SetValue(std::to_string(columnM->getInitialValue()));
@@ -704,7 +704,7 @@ void FieldPropertiesDialog::updateDatatypeInfo()
     choice_collate->Enable(columnM == 0 && indexOk && datatypes[n].isChar);
     if (!choice_collate->IsEnabled())
         choice_collate->SetSelection(wxNOT_FOUND);
-    if (tableM->getDatabase()->getInfo().getODSVersionIsHigherOrEqualTo(12.0)) {
+    if (tableM->getDatabase()->getInfo().getODSVersionIsHigherOrEqualTo(12, 0)) {
         checkbox_identity->Enable(datatypes[n].identity);
         textctrl_initialValue->SetEditable(datatypes[n].identity);
         //textctrl_incrementalValue->SetEditable(datatypes[n].identity);

--- a/src/metadata/CreateDDLVisitor.cpp
+++ b/src/metadata/CreateDDLVisitor.cpp
@@ -227,7 +227,7 @@ void CreateDDLVisitor::visitDatabase(Database& d)
         preSqlM << "/********************* UDFS ***********************/\n\n";
         iterateit<UDFsPtr, UDF>(this, d.getUDFs(), progressIndicatorM);
         
-        if (d.getInfo().getODSVersionIsHigherOrEqualTo(12.0)) {
+        if (d.getInfo().getODSVersionIsHigherOrEqualTo(12, 0)) {
             preSqlM << "/********************* FUNCTIONS ***********************/\n\n";
             iterateit<FunctionSQLsPtr, FunctionSQL>(this, d.getFunctionSQLs(),
                 progressIndicatorM);
@@ -245,7 +245,7 @@ void CreateDDLVisitor::visitDatabase(Database& d)
         iterateit<ProceduresPtr, Procedure>(this, d.getProcedures(),
             progressIndicatorM);
 
-        if (d.getInfo().getODSVersionIsHigherOrEqualTo(12.0)) {
+        if (d.getInfo().getODSVersionIsHigherOrEqualTo(12, 0)) {
             preSqlM << "/******************* PACKAGES ******************/\n\n";
             iterateit<PackagesPtr, Package>(this, d.getPackages(),
                 progressIndicatorM);
@@ -253,7 +253,7 @@ void CreateDDLVisitor::visitDatabase(Database& d)
       
         preSqlM << "/******************** TABLES **********************/\n\n";
         iterateit<TablesPtr, Table>(this, d.getTables(), progressIndicatorM);
-        if (d.getInfo().getODSVersionIsHigherOrEqualTo(11.1)) {
+        if (d.getInfo().getODSVersionIsHigherOrEqualTo(11, 1)) {
             iterateit<GTTablesPtr, GTTable>(this, d.getGTTables(), progressIndicatorM);
         }
 
@@ -270,12 +270,12 @@ void CreateDDLVisitor::visitDatabase(Database& d)
         iterateit<DMLTriggersPtr, DMLTrigger>(this, d.getDMLTriggers(),
             progressIndicatorM);
 
-        if (d.getInfo().getODSVersionIsHigherOrEqualTo(11.1)) {
+        if (d.getInfo().getODSVersionIsHigherOrEqualTo(11, 1)) {
             preSqlM << "/******************** DB TRIGGERS ********************/\n\n";
             iterateit<DBTriggersPtr, DBTrigger>(this, d.getDBTriggers(),
                 progressIndicatorM);
         }
-        if (d.getInfo().getODSVersionIsHigherOrEqualTo(12.0)) {
+        if (d.getInfo().getODSVersionIsHigherOrEqualTo(12, 0)) {
             preSqlM << "/******************** DDL TRIGGERS ********************/\n\n";
             iterateit<DDLTriggersPtr, DDLTrigger>(this, d.getDDLTriggers(),
                 progressIndicatorM);

--- a/src/metadata/database.cpp
+++ b/src/metadata/database.cpp
@@ -1289,7 +1289,7 @@ void Database::loadCollections(ProgressIndicator* progressIndicator)
     pih.init(_("system tables"), collectionCount, 1);
     sysTablesM->load(progressIndicator);
 
-    if (getInfo().getODSVersionIsHigherOrEqualTo(11.1)) {
+    if (getInfo().getODSVersionIsHigherOrEqualTo(11, 1)) {
         pih.init(_("global temporary table"), collectionCount, 2);
         GTTablesM->load(progressIndicator);
     }
@@ -1312,7 +1312,7 @@ void Database::loadCollections(ProgressIndicator* progressIndicator)
     pih.init(_("domains"), collectionCount, 8);
     userDomainsM->load(progressIndicator);
 
-    if (getInfo().getODSVersionIsHigherOrEqualTo(12.0)) {
+    if (getInfo().getODSVersionIsHigherOrEqualTo(12, 0)) {
         pih.init(_("functions SQL"), collectionCount, 9);
         functionSQLsM->load(progressIndicator);
     }
@@ -1326,7 +1326,7 @@ void Database::loadCollections(ProgressIndicator* progressIndicator)
     pih.init(_("exceptions"), collectionCount, 12);
     exceptionsM->load(progressIndicator);
 
-    if (getInfo().getODSVersionIsHigherOrEqualTo(12.0)) {
+    if (getInfo().getODSVersionIsHigherOrEqualTo(12, 0)) {
         pih.init(_("packages"), collectionCount, 13);
         packagesM->load(progressIndicator);
 
@@ -1334,12 +1334,12 @@ void Database::loadCollections(ProgressIndicator* progressIndicator)
         sysPackagesM->load(progressIndicator);
     }
 
-    if (getInfo().getODSVersionIsHigherOrEqualTo(11.1)) {
+    if (getInfo().getODSVersionIsHigherOrEqualTo(11, 1)) {
         pih.init(_("DBTriggers"), collectionCount, 15);
         DBTriggersM->load(progressIndicator);
     }
 
-    if (getInfo().getODSVersionIsHigherOrEqualTo(12.0)) {
+    if (getInfo().getODSVersionIsHigherOrEqualTo(12, 0)) {
         pih.init(_("DDLTriggers"), collectionCount, 16);
         DDLTriggersM->load(progressIndicator);
     }
@@ -1673,16 +1673,16 @@ void Database::getCollections(std::vector<MetadataItem*>& temp, bool system)
     
     temp.push_back(collationsM.get());
 
-    if (getInfo().getODSVersionIsHigherOrEqualTo(11.1)) 
+    if (getInfo().getODSVersionIsHigherOrEqualTo(11, 1)) 
         temp.push_back(DBTriggersM.get());
-    if (getInfo().getODSVersionIsHigherOrEqualTo(12.0)) 
+    if (getInfo().getODSVersionIsHigherOrEqualTo(12, 0)) 
         temp.push_back(DDLTriggersM.get());
     temp.push_back(userDomainsM.get());
     temp.push_back(exceptionsM.get());
-    if (getInfo().getODSVersionIsHigherOrEqualTo(12.0))
+    if (getInfo().getODSVersionIsHigherOrEqualTo(12, 0))
         temp.push_back(functionSQLsM.get());
     temp.push_back(generatorsM.get());
-    if (getInfo().getODSVersionIsHigherOrEqualTo(11.1)) 
+    if (getInfo().getODSVersionIsHigherOrEqualTo(11, 1)) 
         temp.push_back(GTTablesM.get());
     
     if (showOneNodeIndices() && showSystemIndices())
@@ -1690,12 +1690,12 @@ void Database::getCollections(std::vector<MetadataItem*>& temp, bool system)
     else
         temp.push_back(usrIndicesM.get());
 
-    if (getInfo().getODSVersionIsHigherOrEqualTo(12.0)) 
+    if (getInfo().getODSVersionIsHigherOrEqualTo(12, 0)) 
         temp.push_back(packagesM.get());
     temp.push_back(proceduresM.get());
     temp.push_back(rolesM.get());
     // Only push back system objects when they should be shown
-    if (getInfo().getODSVersionIsHigherOrEqualTo(12.0)) {
+    if (getInfo().getODSVersionIsHigherOrEqualTo(12, 0)) {
         if (system && showSystemPackages())
             temp.push_back(sysPackagesM.get());
     }

--- a/src/metadata/table.cpp
+++ b/src/metadata/table.cpp
@@ -557,7 +557,7 @@ void Tables::load(ProgressIndicator* progressIndicator)
     
     wxString stmt = "select rdb$relation_name from rdb$relations "
         "where  (rdb$system_flag = 0 or rdb$system_flag is null) ";
-    if (getDatabase()->getInfo().getODSVersionIsHigherOrEqualTo(11.1))
+    if (getDatabase()->getInfo().getODSVersionIsHigherOrEqualTo(11, 1))
         stmt += " and  (rdb$relation_type in (0, 2)  or rdb$relation_type is null)";
     stmt += " and rdb$view_source is null order by 1";
     setItems(getDatabase()->loadIdentifiers(stmt, progressIndicator));
@@ -586,7 +586,7 @@ void GTTables::acceptVisitor(MetadataItemVisitor* visitor)
 
 void GTTables::load(ProgressIndicator* progressIndicator)
 {
-    if (getDatabase()->getInfo().getODSVersionIsHigherOrEqualTo(11.1)) {
+    if (getDatabase()->getInfo().getODSVersionIsHigherOrEqualTo(11, 1)) {
         wxString stmt = "select rdb$relation_name from rdb$relations"
             " where rdb$relation_type in (4,5) "
             " and rdb$view_source is null order by 1";


### PR DESCRIPTION
Problem
-------
In several places the code used float literals like `getODSVersionIsHigherOrEqualTo(11.1)` 
or `getODSVersionIsHigherOrEqualTo(12.0)`. Because those are floating point literals, the 
call is implicitly converted to the single-argument overload, effectively performing 
`getODSVersionIsHigherOrEqualTo(11)`. This makes the check return true for ODS 11.0 
(Firebird 2.0), causing FlameRobin to issue queries that reference metadata columns 
introduced in later ODS versions (for example `RDB$RELATION_TYPE`), which leads to 
errors such as `Column unknown RDB$RELATION_TYPE`.

Solution
--------
Replace float literals with explicit major/minor integer arguments. For example:
- `getODSVersionIsHigherOrEqualTo(11.1)`  → `getODSVersionIsHigherOrEqualTo(11, 1)`
- `getODSVersionIsHigherOrEqualTo(12.0)`  → `getODSVersionIsHigherOrEqualTo(12, 0)`

This ensures the correct overload is called and prevents FlameRobin from issuing 
metadata queries that rely on features not present in ODS 11.0 (Firebird 2.0).

Reproducible on
---------------
This issue can be reproduced when connecting to a database with ODS **11.0** (Firebird 2.0). 
The mapping of versions is:
- Firebird 1.5 — ODS 10.1
- Firebird 2.0 — ODS 11.0  ← affected
- Firebird 2.1 — ODS 11.1
- Firebird 2.5 — ODS 11.2
- Firebird 3.0 — ODS 12.0
- Firebird 4.0 — ODS 13.0

Notes
-----
This patch only changes calls that used floating point literals and replaces them 
with the proper integer major/minor arguments.
