### PR TITLE
Fix macOS build, Firebird client loading, and SQL editor style highli…

### DIFF
--- a/BUILD.txt
+++ b/BUILD.txt
@@ -152,21 +152,18 @@ Tested on Apple Silicon (arm64) with macOS 26.3.1.
 -- Firebird client library
 
 FlameRobin requires the Firebird client library (libfbclient) at build
-and runtime. Either of these installations is supported:
+and runtime.
 
- a) System Firebird install (https://www.firebirdsql.org/):
+    System Firebird install (https://www.firebirdsql.org/):
     The installer places the framework at:
     /Library/Frameworks/Firebird.framework/
     CMake will find it automatically.
 
- b) Homebrew:
-    $ brew install firebird-client
 
 -- Build steps
 
  1. Install the required tools and libraries:
     $ brew install cmake wxwidgets
-    (and firebird-client if using the Homebrew Firebird option above)
  2. $ cd ~/projects
  3. $ git clone https://github.com/mariuz/flamerobin.git
  4. $ cd flamerobin

--- a/BUILD.txt
+++ b/BUILD.txt
@@ -147,19 +147,47 @@ build for 'release':
 ------------
 
 Assumes Homebrew (https://brew.sh/) is installed.
+Tested on Apple Silicon (arm64) with macOS 26.3.1.
+
+-- Firebird client library
+
+FlameRobin requires the Firebird client library (libfbclient) at build
+and runtime. Either of these installations is supported:
+
+ a) System Firebird install (https://www.firebirdsql.org/):
+    The installer places the framework at:
+    /Library/Frameworks/Firebird.framework/
+    CMake will find it automatically.
+
+ b) Homebrew:
+    $ brew install firebird-client
+
+-- Build steps
 
  1. Install the required tools and libraries:
-    $ brew install cmake firebird-client wxwidgets
+    $ brew install cmake wxwidgets
+    (and firebird-client if using the Homebrew Firebird option above)
  2. $ cd ~/projects
  3. $ git clone https://github.com/mariuz/flamerobin.git
  4. $ cd flamerobin
  5. $ mkdir build
  6. $ cd build
- 7. $ cmake ..
-    Note: if CMake cannot find wxWidgets (e.g. on Apple Silicon where Homebrew
-    installs to /opt/homebrew), pass the Homebrew prefix explicitly:
-    $ cmake -DCMAKE_PREFIX_PATH="$(brew --prefix)" ..
+ 7. $ cmake -DCMAKE_PREFIX_PATH="$(brew --prefix)" ..
+    CMake will locate libfbclient automatically from the Firebird
+    framework or Homebrew. If your Firebird client is in a custom
+    location, set CMAKE_PREFIX_PATH or FBLIB accordingly:
+    $ cmake -DCMAKE_PREFIX_PATH="/path/to/firebird" ..
  8. $ make
- 9. To run FlameRobin:
+ 9. To run FlameRobin directly from the build directory:
     $ open flamerobin.app
+
+-- Install to /Applications (optional)
+
+    $ sudo cmake --install .
+
+-- Notes
+
+ * The app bundle embeds an rpath pointing to where libfbclient was
+   found at build time, so the app runs without DYLD_LIBRARY_PATH.
+ * If you move or reinstall Firebird after building, rebuild from step 7.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,8 +439,24 @@ if(APPLE)
 	message(WARNING "MacOS build is untested.\n"
 	                "Please get in contact to tell us of your results.")
 	add_definitions(-DIBPP_DARWIN)
-	list(APPEND FR_LIBS -lfbclient)
-        list(APPEND FR_LIBS -L/Library/Frameworks/Firebird.framework/Versions/Current/Libraries)
+        set(FR_FIREBIRD_HINT_DIRS
+                "/Library/Frameworks/Firebird.framework/Resources/lib"
+                "/Library/Frameworks/Firebird.framework/Libraries"
+                "/opt/homebrew/lib"
+                "/usr/local/lib"
+        )
+        find_library(FBCLIENT_LIBRARY
+                NAMES fbclient libfbclient
+                HINTS ${FR_FIREBIRD_HINT_DIRS}
+        )
+        if (FBCLIENT_LIBRARY)
+                message(STATUS "Using Firebird client library: ${FBCLIENT_LIBRARY}")
+                list(APPEND FR_LIBS ${FBCLIENT_LIBRARY})
+                get_filename_component(FBCLIENT_LIBRARY_DIR ${FBCLIENT_LIBRARY} DIRECTORY)
+                list(APPEND FR_RPATHS ${FBCLIENT_LIBRARY_DIR})
+        else ()
+                message(FATAL_ERROR "Could not find libfbclient on macOS. Set CMAKE_PREFIX_PATH or FBLIB to a valid Firebird client location.")
+        endif ()
         
     list(APPEND SOURCE_LIST
         ${SOURCEDIR}/gui/mac/StyleGuideMAC.cpp
@@ -538,6 +554,15 @@ endif (APPLE)
 
 target_link_libraries(${PROJECT_NAME} IBPP ${wxWidgets_LIBRARIES} ${FR_LIBS})
 
+if (APPLE)
+        set_target_properties(${PROJECT_NAME} PROPERTIES
+                BUILD_WITH_INSTALL_RPATH FALSE
+                BUILD_RPATH "${FR_RPATHS}"
+                INSTALL_RPATH "${FR_RPATHS}"
+                MACOSX_RPATH TRUE
+        )
+endif (APPLE)
+
 
 #--------------------------------------
 # Install
@@ -578,9 +603,10 @@ if (UNIX AND NOT APPLE)
 endif (UNIX AND NOT APPLE)
 
 if (APPLE)
-        install(
-                TARGETS flamerobin
-                DESTINATION /Applications
-        )
+	install(
+		TARGETS flamerobin
+		BUNDLE DESTINATION /Applications
+		RUNTIME DESTINATION bin
+	)
 endif (APPLE)
 

--- a/src/gui/ExecuteSqlFrame.cpp
+++ b/src/gui/ExecuteSqlFrame.cpp
@@ -492,8 +492,13 @@ void SqlEditor::setFont()
 
 void SqlEditor::setupStyles()
 {
+    // 1) Set STYLE_DEFAULT (fg/bg) from the theme.
     stylerManager().assignGlobal(this);
+    // 2) Propagate STYLE_DEFAULT to every token ID (fixes unspecified tokens
+    //    like identifiers that would otherwise inherit system dark defaults).
     StyleClearAll();
+    // 3) Re-apply global styles that StyleClearAll just wiped (brace highlight, etc.).
+    stylerManager().assignGlobal(this);
     stylerManager().assignLexer(this);
     SetLexer(wxSTC_LEX_SQL);
     stylerManager().assignMargin(this);

--- a/src/ibpp/_ibpp.cpp
+++ b/src/ibpp/_ibpp.cpp
@@ -44,7 +44,18 @@
 #include <stdlib.h>
 
 //empty string terminated list of Firebird SO libraries to try in turn
+#ifdef IBPP_DARWIN
+static const char* fblibs[] = {
+	"/Library/Frameworks/Firebird.framework/Resources/lib/libfbclient.dylib",
+	"/Library/Frameworks/Firebird.framework/Libraries/libfbclient.dylib",
+	"/opt/homebrew/lib/libfbclient.dylib",
+	"/usr/local/lib/libfbclient.dylib",
+	"libfbclient.dylib",
+	""
+};
+#else
 static const char* fblibs[] = {"libfbembed.so.2.5","libfbembed.so.2.1","libfbclient.so.2",""};
+#endif
 
 #endif
 


### PR DESCRIPTION
CMakeLists.txt:
- Use find_library() to locate libfbclient on macOS, checking Firebird.framework and Homebrew paths instead of hardcoded -L flag.
- Embed rpath in the app bundle so libfbclient resolves at runtime without needing DYLD_LIBRARY_PATH.
- Fix install target to use BUNDLE DESTINATION instead of hardcoded /Applications so the user controls where to install.

src/ibpp/_ibpp.cpp:
- Add macOS-specific .dylib fallback list for runtime dlopen(), covering Firebird.framework (system install) and Homebrew locations.

src/gui/ExecuteSqlFrame.cpp: [Issue #445](https://github.com/mariuz/flamerobin/issues/445) 
- Fix SQL editor style initialisation order in setupStyles(). The sequence is now: assignGlobal -> StyleClearAll -> assignGlobal. This seeds all unspecified lexer token IDs (identifiers, NEW/OLD trigger variables, column names, etc.) with the theme default style (white background, black text) instead of inheriting dark system defaults on macOS. Special styles like brace highlight are preserved because assignGlobal is called again after StyleClearAll. 

<img width="1255" height="756" alt="image" src="https://github.com/user-attachments/assets/f6aa5cad-872f-4392-bce0-2f119e0ccdd1" />
