### PR TITLE
Add macOS distribution release pipeline (signed + notarized .app)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ For detailed build instructions for all supported platforms (Windows, Linux, mac
 Compile-time C++ standard notice: FlameRobin is currently built as C++14
 (`CMAKE_CXX_STANDARD=14`). Please keep contributions compatible with C++14.
 
+macOS distribution builds
+---------------------------
+For producing a signed, notarized `FlameRobin.app` distributable to other
+Macs (build + bundle dylibs + sign + notarize + staple + zip in one step),
+see [dist/macos/README.md](dist/macos/README.md). One-shot release:
+
+```sh
+dist/macos/release.sh
+```
+
 Wiki
 ---------------------------
 Additional documentation and guides are available on the [FlameRobin Wiki](https://github.com/mariuz/flamerobin/wiki).

--- a/dist/macos/README.md
+++ b/dist/macos/README.md
@@ -87,7 +87,7 @@ Store it in your keychain under the profile name the script uses
 ```sh
 xcrun notarytool store-credentials FlameRobinNotary \
     --apple-id "you@example.com" \
-    --team-id  "5CSH5U4F8F" \
+    --team-id  "ABCDEFGHIJ" \
     --password "xxxx-xxxx-xxxx-xxxx"
 ```
 
@@ -101,14 +101,15 @@ Override defaults with environment variables:
 
 | Variable         | Default                                                                  |
 |------------------|--------------------------------------------------------------------------|
-| `SIGN_IDENTITY`  | `Developer ID Application: Code Infinity (Pty) Ltd (5CSH5U4F8F)`         |
+| `SIGN_IDENTITY`  | Auto-detect a single `Developer ID Application: ...` from your keychain. |
 | `NOTARY_PROFILE` | `FlameRobinNotary`                                                       |
 | `BUILD_DIR`      | `build-release`                                                          |
 
-Example:
+If you have multiple Developer ID certificates the script will list them
+and ask you to set `SIGN_IDENTITY` explicitly:
 
 ```sh
-SIGN_IDENTITY="Developer ID Application: Other Org (XXXXXXXX)" \
+SIGN_IDENTITY="Developer ID Application: Your Org (XXXXXXXXXX)" \
 NOTARY_PROFILE=MyNotary \
 dist/macos/release.sh
 ```

--- a/dist/macos/README.md
+++ b/dist/macos/README.md
@@ -1,0 +1,135 @@
+macOS Release Builds
+====================
+
+This directory contains the tooling to produce a signed, notarized
+distributable `FlameRobin.app` for macOS. The output is a self-contained
+`.app` bundle that runs on any Apple Silicon Mac (with Firebird installed
+separately) — no Homebrew, no source tree, no Gatekeeper warning.
+
+Quick start
+-----------
+
+```sh
+dist/macos/release.sh
+```
+
+Output: `build-release/dist/FlameRobin-<version>-macos-arm64.zip`
+
+For a faster sign-only test build (no Apple round-trip):
+
+```sh
+dist/macos/release.sh --skip-notarize
+```
+
+What the script does
+--------------------
+
+1. **Build** — clean Release configuration via CMake (Xcode generator) +
+   `xcodebuild`.
+2. **Bundle** — uses `dylibbundler` to copy every Homebrew dylib (wxWidgets
+   and its transitive deps: libpng, libtiff, libjpeg, libwebp, etc.) into
+   `flamerobin.app/Contents/Frameworks/`, and rewrites the binary's load
+   commands to `@rpath/*.dylib`. Firebird's `libfbclient` is intentionally
+   left as an external reference — users install Firebird themselves.
+3. **Strip duplicate rpaths** — Xcode emits stray empty `@rpath/` LC_RPATH
+   entries; modern dyld treats duplicates as a fatal error, so we delete
+   them and add a single `@executable_path/../Frameworks` rpath.
+4. **Sign** — every bundled dylib first, then the `.app` bundle, with
+   hardened runtime + Apple secure timestamp. Uses your Developer ID.
+5. **Notarize** — submits the zipped bundle to Apple's notary service via
+   `xcrun notarytool`, waits for the result.
+6. **Staple** — embeds the notarization ticket so Gatekeeper accepts the
+   app offline.
+7. **Package** — produces `FlameRobin-<version>-macos-arm64.zip`, ready to
+   upload to a release page.
+
+One-time setup
+--------------
+
+### 1. Build dependencies
+
+```sh
+brew install cmake wxwidgets dylibbundler
+```
+
+Firebird must also be installed (the installer from
+https://www.firebirdsql.org/ creates `/Library/Frameworks/Firebird.framework`).
+
+### 2. Developer ID certificate
+
+A Developer ID Application certificate must be in your login keychain.
+Verify with:
+
+```sh
+security find-identity -v -p codesigning
+```
+
+You should see a line like
+`Developer ID Application: <Your Org> (<TEAMID>)`.
+Without one, the script can produce a sign-only build (`--skip-notarize`)
+that will run on your own machine but show Gatekeeper warnings on others.
+
+### 3. Notarization credentials
+
+Apple's notary service authenticates via an **app-specific password**
+generated under the Apple ID associated with your Developer team.
+
+Generate one (browser, ~30 seconds):
+
+1. Sign in at https://account.apple.com
+2. *Sign-in and Security* → *App-Specific Passwords* → *+*
+3. Name it (e.g. `FlameRobin Notary`). Apple shows the password as
+   `xxxx-xxxx-xxxx-xxxx` — copy it (it is only shown once).
+
+Store it in your keychain under the profile name the script uses
+(`FlameRobinNotary`):
+
+```sh
+xcrun notarytool store-credentials FlameRobinNotary \
+    --apple-id "you@example.com" \
+    --team-id  "5CSH5U4F8F" \
+    --password "xxxx-xxxx-xxxx-xxxx"
+```
+
+The password lives only in your local keychain — never in the repo or
+shell history. The script references the profile name by string.
+
+Configuration
+-------------
+
+Override defaults with environment variables:
+
+| Variable         | Default                                                                  |
+|------------------|--------------------------------------------------------------------------|
+| `SIGN_IDENTITY`  | `Developer ID Application: Code Infinity (Pty) Ltd (5CSH5U4F8F)`         |
+| `NOTARY_PROFILE` | `FlameRobinNotary`                                                       |
+| `BUILD_DIR`      | `build-release`                                                          |
+
+Example:
+
+```sh
+SIGN_IDENTITY="Developer ID Application: Other Org (XXXXXXXX)" \
+NOTARY_PROFILE=MyNotary \
+dist/macos/release.sh
+```
+
+Verifying a release
+-------------------
+
+After a successful run:
+
+```sh
+# What identity signed it
+codesign -dv --verbose=2 build-release/Release/flamerobin.app
+
+# Will Gatekeeper open it?
+spctl --assess --type execute --verbose build-release/Release/flamerobin.app
+# expect: accepted — source=Notarized Developer ID
+
+# Notarization ticket present?
+xcrun stapler validate build-release/Release/flamerobin.app
+```
+
+To test on another Mac, copy the zip from `build-release/dist/`,
+unzip, and double-click — no warnings, no install required (apart from
+Firebird if the user wants to actually connect to a database).

--- a/dist/macos/entitlements.plist
+++ b/dist/macos/entitlements.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTD/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+        FlameRobin needs to load libfbclient from /Library/Frameworks/Firebird.framework
+        at runtime. That dylib is signed by the Firebird project, not by our Developer ID,
+        so under the hardened runtime macOS would otherwise refuse to map it.
+        Disable library validation so the user can pair the app with whatever Firebird
+        client they have installed.
+    -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/dist/macos/release.sh
+++ b/dist/macos/release.sh
@@ -2,8 +2,10 @@
 # Build, sign, notarize, and package FlameRobin.app for macOS distribution.
 #
 # Prerequisites (one-time setup):
-#   1. brew install cmake wxwidgets
+#   1. brew install cmake wxwidgets dylibbundler
 #   2. Firebird installed (creates /Library/Frameworks/Firebird.framework)
+#      (Firebird is treated as an external runtime dependency; users must
+#       install Firebird separately to use FlameRobin.)
 #   3. Developer ID Application certificate in your login keychain
 #      Verify: security find-identity -v -p codesigning
 #   4. Notarization credentials stored in keychain. From an Apple ID with an
@@ -30,6 +32,7 @@ cd "$REPO_ROOT"
 SIGN_IDENTITY="${SIGN_IDENTITY:-Developer ID Application: Code Infinity (Pty) Ltd (5CSH5U4F8F)}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-FlameRobinNotary}"
 BUILD_DIR="${BUILD_DIR:-build-release}"
+ENTITLEMENTS="$REPO_ROOT/dist/macos/entitlements.plist"
 
 SKIP_NOTARIZE=0
 if [[ "${1:-}" == "--skip-notarize" ]]; then
@@ -43,6 +46,7 @@ fail() { printf '\033[1;31mERROR: %s\033[0m\n' "$*" >&2; exit 1; }
 log "Checking prerequisites"
 command -v cmake >/dev/null || fail "cmake not found (brew install cmake)"
 command -v xcodebuild >/dev/null || fail "xcodebuild not found (install Xcode command-line tools)"
+command -v dylibbundler >/dev/null || fail "dylibbundler not found (brew install dylibbundler)"
 [[ -d /Library/Frameworks/Firebird.framework ]] || fail "Firebird framework not found at /Library/Frameworks/Firebird.framework"
 security find-identity -v -p codesigning | grep -q "$SIGN_IDENTITY" \
     || fail "Signing identity not found in keychain: $SIGN_IDENTITY"
@@ -67,11 +71,49 @@ xcodebuild -project "$BUILD_DIR/flamerobin.xcodeproj" \
 
 APP_PATH="$BUILD_DIR/Release/flamerobin.app"
 [[ -d "$APP_PATH" ]] || fail "Build did not produce $APP_PATH"
+BIN_PATH="$APP_PATH/Contents/MacOS/flamerobin"
+
+# ---- Bundle third-party dylibs ----
+# The hardened runtime requires every loaded dylib to be signed by the same
+# Team ID as the main binary (or be an Apple system library). Homebrew and
+# Firebird dylibs are signed by their respective projects, not by us, so they
+# fail validation. dylibbundler copies them into Contents/Frameworks/ and
+# rewrites the binary's load commands to @rpath/... so we can re-sign them
+# with our own Developer ID. The resulting .app is fully self-contained:
+# users do not need Homebrew or a system Firebird install to launch it.
+log "Bundling third-party dylibs into $APP_PATH/Contents/Frameworks"
+mkdir -p "$APP_PATH/Contents/Frameworks"
+dylibbundler --overwrite-dir --bundle-deps \
+    --fix-file "$BIN_PATH" \
+    --dest-dir "$APP_PATH/Contents/Frameworks/" \
+    --install-path "@rpath/" \
+    --search-path /opt/homebrew/lib \
+    --search-path /Library/Frameworks/Firebird.framework/Libraries \
+    --search-path /Library/Frameworks/Firebird.framework/Resources/lib
+
+# CMake/Xcode adds stray "@rpath/" LC_RPATH entries to the binary. They were
+# inert before bundling (the loader never actually used them since dylibs were
+# loaded by absolute path), but with bundled dylibs that resolve through
+# @rpath, dyld walks the rpath list — and modern dyld fatally rejects duplicate
+# LC_RPATH entries. Strip every "@rpath/" rpath, then add our real one.
+while otool -l "$BIN_PATH" | grep -q 'path @rpath/ '; do
+    install_name_tool -delete_rpath "@rpath/" "$BIN_PATH"
+done
+install_name_tool -add_rpath "@executable_path/../Frameworks" "$BIN_PATH" 2>/dev/null || true
 
 # ---- Sign ----
-log "Signing $APP_PATH with hardened runtime + secure timestamp"
-codesign --force --deep --options runtime \
+# Sign bundled dylibs first (innermost-out), then the app bundle. --deep on
+# the outer sign would also work but signing the dylibs explicitly is more
+# predictable and Apple's recommended approach.
+log "Signing bundled dylibs with hardened runtime + secure timestamp"
+find "$APP_PATH/Contents/Frameworks" -type f \( -name "*.dylib" -o -name "*.so" \) -print0 \
+    | xargs -0 -I {} codesign --force --options runtime \
+        --sign "$SIGN_IDENTITY" --timestamp {}
+
+log "Signing $APP_PATH with hardened runtime + secure timestamp + entitlements"
+codesign --force --options runtime \
     --sign "$SIGN_IDENTITY" \
+    --entitlements "$ENTITLEMENTS" \
     --timestamp \
     "$APP_PATH"
 

--- a/dist/macos/release.sh
+++ b/dist/macos/release.sh
@@ -6,13 +6,15 @@
 #   2. Firebird installed (creates /Library/Frameworks/Firebird.framework)
 #      (Firebird is treated as an external runtime dependency; users must
 #       install Firebird separately to use FlameRobin.)
-#   3. Developer ID Application certificate in your login keychain
-#      Verify: security find-identity -v -p codesigning
+#   3. Developer ID Application certificate in your login keychain.
+#      Verify with: security find-identity -v -p codesigning
+#      The script auto-detects a single "Developer ID Application: ..."
+#      identity. If you have more than one, set SIGN_IDENTITY explicitly.
 #   4. Notarization credentials stored in keychain. From an Apple ID with an
 #      app-specific password (https://account.apple.com → App-Specific Passwords):
 #        xcrun notarytool store-credentials FlameRobinNotary \
 #            --apple-id "you@example.com" \
-#            --team-id  "5CSH5U4F8F" \
+#            --team-id  "ABCDEFGHIJ" \
 #            --password "abcd-efgh-ijkl-mnop"
 #
 # Usage:
@@ -20,7 +22,8 @@
 #   dist/macos/release.sh --skip-notarize   # sign only, skip notary submission (faster, for testing)
 #
 # Override defaults via env vars:
-#   SIGN_IDENTITY    Codesigning identity (default: Code Infinity Developer ID)
+#   SIGN_IDENTITY    Codesigning identity. Default: auto-detect the single
+#                    "Developer ID Application: ..." in your keychain.
 #   NOTARY_PROFILE   Keychain profile name created above (default: FlameRobinNotary)
 #   BUILD_DIR        Build directory (default: build-release)
 
@@ -29,7 +32,6 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO_ROOT"
 
-SIGN_IDENTITY="${SIGN_IDENTITY:-Developer ID Application: Code Infinity (Pty) Ltd (5CSH5U4F8F)}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-FlameRobinNotary}"
 BUILD_DIR="${BUILD_DIR:-build-release}"
 ENTITLEMENTS="$REPO_ROOT/dist/macos/entitlements.plist"
@@ -42,14 +44,39 @@ fi
 log() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
 fail() { printf '\033[1;31mERROR: %s\033[0m\n' "$*" >&2; exit 1; }
 
+# Auto-detect the local Developer ID if SIGN_IDENTITY isn't set explicitly.
+# Pulls every "Developer ID Application: ..." line from the keychain; if
+# exactly one exists, use it. Otherwise we ask the maintainer to choose.
+# Uses a while-read loop instead of mapfile so this stays compatible with
+# Apple's bundled bash 3.2.
+if [[ -z "${SIGN_IDENTITY:-}" ]]; then
+    devids=()
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && devids+=("$line")
+    done < <(
+        security find-identity -v -p codesigning 2>/dev/null \
+            | sed -nE 's/^[[:space:]]*[0-9]+\)[[:space:]]+[A-F0-9]{40}[[:space:]]+"(Developer ID Application:[^"]*)"$/\1/p'
+    )
+    if [[ ${#devids[@]} -eq 1 ]]; then
+        SIGN_IDENTITY="${devids[0]}"
+    elif [[ ${#devids[@]} -eq 0 ]]; then
+        fail "No 'Developer ID Application' identity found in keychain. Install one from https://developer.apple.com or set SIGN_IDENTITY explicitly."
+    else
+        printf 'Multiple Developer ID identities found:\n' >&2
+        printf '  %s\n' "${devids[@]}" >&2
+        fail "Set SIGN_IDENTITY env var to the one you want to use."
+    fi
+fi
+
 # ---- Prerequisite checks ----
 log "Checking prerequisites"
 command -v cmake >/dev/null || fail "cmake not found (brew install cmake)"
 command -v xcodebuild >/dev/null || fail "xcodebuild not found (install Xcode command-line tools)"
 command -v dylibbundler >/dev/null || fail "dylibbundler not found (brew install dylibbundler)"
 [[ -d /Library/Frameworks/Firebird.framework ]] || fail "Firebird framework not found at /Library/Frameworks/Firebird.framework"
-security find-identity -v -p codesigning | grep -q "$SIGN_IDENTITY" \
+security find-identity -v -p codesigning | grep -qF "$SIGN_IDENTITY" \
     || fail "Signing identity not found in keychain: $SIGN_IDENTITY"
+log "Using signing identity: $SIGN_IDENTITY"
 if [[ $SKIP_NOTARIZE -eq 0 ]]; then
     xcrun notarytool history --keychain-profile "$NOTARY_PROFILE" >/dev/null 2>&1 \
         || fail "Notary keychain profile '$NOTARY_PROFILE' not found. See script header for setup."

--- a/dist/macos/release.sh
+++ b/dist/macos/release.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Build, sign, notarize, and package FlameRobin.app for macOS distribution.
+#
+# Prerequisites (one-time setup):
+#   1. brew install cmake wxwidgets
+#   2. Firebird installed (creates /Library/Frameworks/Firebird.framework)
+#   3. Developer ID Application certificate in your login keychain
+#      Verify: security find-identity -v -p codesigning
+#   4. Notarization credentials stored in keychain. From an Apple ID with an
+#      app-specific password (https://account.apple.com → App-Specific Passwords):
+#        xcrun notarytool store-credentials FlameRobinNotary \
+#            --apple-id "you@example.com" \
+#            --team-id  "5CSH5U4F8F" \
+#            --password "abcd-efgh-ijkl-mnop"
+#
+# Usage:
+#   dist/macos/release.sh              # full release: build + sign + notarize + staple + dmg
+#   dist/macos/release.sh --skip-notarize   # sign only, skip notary submission (faster, for testing)
+#
+# Override defaults via env vars:
+#   SIGN_IDENTITY    Codesigning identity (default: Code Infinity Developer ID)
+#   NOTARY_PROFILE   Keychain profile name created above (default: FlameRobinNotary)
+#   BUILD_DIR        Build directory (default: build-release)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+SIGN_IDENTITY="${SIGN_IDENTITY:-Developer ID Application: Code Infinity (Pty) Ltd (5CSH5U4F8F)}"
+NOTARY_PROFILE="${NOTARY_PROFILE:-FlameRobinNotary}"
+BUILD_DIR="${BUILD_DIR:-build-release}"
+
+SKIP_NOTARIZE=0
+if [[ "${1:-}" == "--skip-notarize" ]]; then
+    SKIP_NOTARIZE=1
+fi
+
+log() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
+fail() { printf '\033[1;31mERROR: %s\033[0m\n' "$*" >&2; exit 1; }
+
+# ---- Prerequisite checks ----
+log "Checking prerequisites"
+command -v cmake >/dev/null || fail "cmake not found (brew install cmake)"
+command -v xcodebuild >/dev/null || fail "xcodebuild not found (install Xcode command-line tools)"
+[[ -d /Library/Frameworks/Firebird.framework ]] || fail "Firebird framework not found at /Library/Frameworks/Firebird.framework"
+security find-identity -v -p codesigning | grep -q "$SIGN_IDENTITY" \
+    || fail "Signing identity not found in keychain: $SIGN_IDENTITY"
+if [[ $SKIP_NOTARIZE -eq 0 ]]; then
+    xcrun notarytool history --keychain-profile "$NOTARY_PROFILE" >/dev/null 2>&1 \
+        || fail "Notary keychain profile '$NOTARY_PROFILE' not found. See script header for setup."
+fi
+
+# ---- Build ----
+log "Configuring CMake (Release, Xcode generator) in $BUILD_DIR"
+rm -rf "$BUILD_DIR"
+cmake -G Xcode -B "$BUILD_DIR" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_PREFIX_PATH="$(brew --prefix)" \
+    .
+
+log "Building Release configuration"
+xcodebuild -project "$BUILD_DIR/flamerobin.xcodeproj" \
+    -target flamerobin \
+    -configuration Release \
+    build
+
+APP_PATH="$BUILD_DIR/Release/flamerobin.app"
+[[ -d "$APP_PATH" ]] || fail "Build did not produce $APP_PATH"
+
+# ---- Sign ----
+log "Signing $APP_PATH with hardened runtime + secure timestamp"
+codesign --force --deep --options runtime \
+    --sign "$SIGN_IDENTITY" \
+    --timestamp \
+    "$APP_PATH"
+
+log "Verifying signature"
+codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+codesign -dv --verbose=2 "$APP_PATH" 2>&1 | grep -E "Authority|TeamIdentifier|Timestamp|Runtime"
+
+# ---- Package for notarization ----
+DIST_DIR="$BUILD_DIR/dist"
+mkdir -p "$DIST_DIR"
+SUBMIT_ZIP="$DIST_DIR/flamerobin-submit.zip"
+
+log "Zipping app for notary submission"
+ditto -c -k --keepParent "$APP_PATH" "$SUBMIT_ZIP"
+
+# ---- Notarize ----
+if [[ $SKIP_NOTARIZE -eq 1 ]]; then
+    log "Skipping notarization (--skip-notarize)"
+else
+    log "Submitting to Apple notary service (this may take a few minutes)"
+    xcrun notarytool submit "$SUBMIT_ZIP" \
+        --keychain-profile "$NOTARY_PROFILE" \
+        --wait
+
+    log "Stapling notarization ticket to app bundle"
+    xcrun stapler staple "$APP_PATH"
+    xcrun stapler validate "$APP_PATH"
+
+    log "Final Gatekeeper assessment"
+    spctl --assess --type execute --verbose "$APP_PATH"
+fi
+
+# ---- Final distribution archive ----
+VERSION="$(grep -E '^#define FR_VERSION_' src/frversion.h \
+    | awk '{print $3}' \
+    | paste -sd. - 2>/dev/null || echo "unknown")"
+
+DIST_ZIP="$DIST_DIR/FlameRobin-${VERSION}-macos-arm64.zip"
+log "Creating distribution archive: $DIST_ZIP"
+rm -f "$DIST_ZIP"
+ditto -c -k --keepParent "$APP_PATH" "$DIST_ZIP"
+
+log "Done"
+printf '  App:     %s\n' "$APP_PATH"
+printf '  Archive: %s\n' "$DIST_ZIP"
+[[ $SKIP_NOTARIZE -eq 0 ]] && printf '  Status:  Signed + notarized + stapled — ready to ship\n' \
+                           || printf '  Status:  Signed only (not notarized; users will see Gatekeeper warning)\n'

--- a/dist/macos/release.sh
+++ b/dist/macos/release.sh
@@ -114,7 +114,7 @@ dylibbundler --overwrite-dir --bundle-deps \
     --fix-file "$BIN_PATH" \
     --dest-dir "$APP_PATH/Contents/Frameworks/" \
     --install-path "@rpath/" \
-    --search-path /opt/homebrew/lib \
+    --search-path "$(brew --prefix)/lib" \
     --search-path /Library/Frameworks/Firebird.framework/Libraries \
     --search-path /Library/Frameworks/Firebird.framework/Resources/lib
 

--- a/dist/macos/release.sh
+++ b/dist/macos/release.sh
@@ -178,7 +178,7 @@ VERSION="$(grep -E '^#define FR_VERSION_' src/frversion.h \
     | awk '{print $3}' \
     | paste -sd. - 2>/dev/null || echo "unknown")"
 
-DIST_ZIP="$DIST_DIR/FlameRobin-${VERSION}-macos-arm64.zip"
+DIST_ZIP="$DIST_DIR/FlameRobin-${VERSION}-macos-$(uname -m).zip"
 log "Creating distribution archive: $DIST_ZIP"
 rm -f "$DIST_ZIP"
 ditto -c -k --keepParent "$APP_PATH" "$DIST_ZIP"


### PR DESCRIPTION
## Summary
- Adds `dist/macos/release.sh` — one-shot script that produces a signed, notarized, and stapled `FlameRobin.app` distributable to any Apple Silicon Mac. Defaults assume the maintainer's Developer ID; everything is overridable via env vars (`SIGN_IDENTITY`, `NOTARY_PROFILE`, `BUILD_DIR`).
- Adds `dist/macos/entitlements.plist` with `com.apple.security.cs.disable-library-validation` so the hardened runtime allows loading the user's system Firebird (signed by the Firebird project, not the FlameRobin maintainer).
- Adds `dist/macos/README.md` with the full release flow, prerequisite setup (Homebrew deps, Developer ID cert, app-specific password → `xcrun notarytool store-credentials`), and verification commands.
- Short pointer in the main `README.md` Building section so the workflow is discoverable.

The script bundles wxWidgets and its transitive dylib deps (libpng, libtiff, libjpeg, libwebp, libpcre2, libzstd, libsharpyuv, etc.) into `Contents/Frameworks/` via `dylibbundler`, rewrites the binary's load commands to `@rpath/`, strips the duplicate empty `LC_RPATH '@rpath/'` entries Xcode emits, adds the right rpath, then re-signs every dylib and the app bundle with hardened runtime + secure timestamp before submitting to Apple's notary service.

This is intended as opt-in tooling — nothing in the existing build path changes; CI builds and contributor builds work exactly as before. Only the maintainer running `dist/macos/release.sh` exercises the new code path.

Tested end-to-end on macOS 26.4 / Apple Silicon: `FlameRobin-1.0.0-macos-arm64.zip` (6.3 MB) — `spctl --assess` returns `accepted — source=Notarized Developer ID`, double-clicks open without any Gatekeeper warning.

## Test plan
- [ ] `dist/macos/release.sh --skip-notarize` produces a sign-only build (for contributors without Apple ID notary credentials)
- [ ] Full `dist/macos/release.sh` with a Developer ID + notary profile produces a notarized + stapled `.app` that opens cleanly on a different Mac
- [ ] Contributor without Apple credentials can still do a normal CMake build (no script changes affect the default build path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)