### PR TITLE
Fix doubled row count in grid delete confirmation

### DIFF
--- a/src/gui/ExecuteSqlFrame.cpp
+++ b/src/gui/ExecuteSqlFrame.cpp
@@ -1879,8 +1879,10 @@ wxArrayInt getSelectedGridRows(DataGrid* grid)
     wxArrayInt rows;
     if (grid)
     {
-        // add fully selected rows
-        rows = grid->GetSelectedRows();
+        // Don't include grid->GetSelectedRows(): on macOS (and some wx versions)
+        // a single-cell click is reported in both GetSelectedRows() and the
+        // selection blocks below, so the row gets counted twice. The blocks
+        // alone correctly cover both row-header clicks and cell selections.
 
         // add rows in selection blocks that span all columns
         wxGridCellCoordsArray tlCells(grid->GetSelectionBlockTopLeft());
@@ -1921,7 +1923,7 @@ void ExecuteSqlFrame::OnMenuGridDeleteRow(wxCommandEvent& WXUNUSED(event))
     {
         bool agreed = wxOK == showQuestionDialog(this,
             _("Do you really want to delete multiple rows?"),
-            wxString::Format(_("You have more than one row selected. Are you sure you wish to delete all %d selected rows?"), count),
+            wxString::Format(_("You have more than one row selected. Are you sure you wish to delete all %d selected rows?"), int(count)),
             AdvancedMessageDialogButtonsOkCancel(_("Delete")));
         if (!agreed)
             return;


### PR DESCRIPTION
## Summary
In wxGrid 3.x, a row-header click (or a Ctrl+A) populates **both** `GetSelectedRows()` and the selection blocks returned by `GetSelectionBlockTopLeft/BottomRight`. The original `getSelectedGridRows` helper appended both lists without dedup, so each row got counted twice — selecting one row produced *"Are you sure you wish to delete all 2 selected rows?"*.

Drop the redundant `GetSelectedRows()` call. The existing block check (`tl.GetCol() == 0 && br.GetCol() == numCols - 1`) already covers row-header selections — just without double-counting.

Also cast the `size_t` count to `int` when passing to `wxString::Format` with `%d` — passing a `size_t` to `%d` is undefined on 64-bit platforms.

Reproduced on macOS arm64 / wxWidgets 3.3.2; fix verified on the same build.

## Test plan
- [ ] Open Execute SQL Frame, run a query returning multiple rows
- [ ] Click on a single row in the grid; choose Delete row(s)
- [ ] Dialog should not appear at all (single-row delete path) — previously showed "delete all 2 selected rows?"
- [ ] Select 2 rows by Shift-click → dialog correctly says "delete all 2 selected rows?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)