### PR TITLE
Fix #444: enable Delete row(s) when all rows selected via Ctrl+A

### DIFF
--- a/src/gui/ExecuteSqlFrame.cpp
+++ b/src/gui/ExecuteSqlFrame.cpp
@@ -3070,20 +3070,21 @@ void ExecuteSqlFrame::OnMenuUpdateGridDeleteRow(wxUpdateUIEvent& event)
         return;
     }
 
-    bool colsSelected = grid_data->GetSelectedCols().GetCount() > 0;
+    // Issue #444: when the user does Ctrl+A or clicks the corner cell,
+    // wxGrid reports both rows AND columns as selected. The previous
+    // colsSelected short-circuit then disabled the delete-row button,
+    // even though getSelectedGridRows correctly returns every row in
+    // that case. Compute selRows first; only block when it is purely a
+    // column selection (no row data identified).
+    wxArrayInt selRows(getSelectedGridRows(grid_data));
     bool deletableRows = false;
-
-    if (!colsSelected)
+    for (size_t i = 0; !deletableRows && i < selRows.GetCount(); ++i)
     {
-        wxArrayInt selRows(getSelectedGridRows(grid_data));
-        for (size_t i = 0; !deletableRows && i < selRows.GetCount(); ++i)
-        {
-            if (tb->canRemoveRow(selRows[i]))
-                deletableRows = true;
-        }
+        if (tb->canRemoveRow(selRows[i]))
+            deletableRows = true;
     }
 
-    event.Enable(!colsSelected && deletableRows);
+    event.Enable(deletableRows);
 }
 
 void ExecuteSqlFrame::OnGridCellChange(wxGridEvent& event)


### PR DESCRIPTION
## Summary
Closes #444.

`OnMenuUpdateGridDeleteRow` short-circuits the Delete-row button to disabled whenever any column is reported as selected:

```cpp
bool colsSelected = grid_data->GetSelectedCols().GetCount() > 0;
// ...
event.Enable(!colsSelected && deletableRows);
```

But wxGrid reports a Ctrl+A (or corner-cell click) as **both** all-rows AND all-cols selected — so the button greys out exactly when the user wants to delete every row. The reporter has to deselect a row and re-select it to work around this.

`getSelectedGridRows` already correctly handles the select-all case via the "block spans all columns" check, so the `colsSelected` gate is redundant. Drop it; enable the button whenever at least one row in the selection can be removed.

## Test plan
- [ ] Open Execute SQL Frame, run a query returning multiple deletable rows
- [ ] Press Ctrl+A (or click the corner cell) to select all
- [ ] "Delete row(s) from recordset" should be enabled — previously greyed out
- [ ] Confirming the dialog deletes all rows
- [ ] Selecting only column headers (click a column header, no row selected) still correctly leaves the button disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)