### PR TITLE
Fix #390: speed up data-grid context menu with large selections

### DIFF
--- a/src/gui/ExecuteSqlFrame.cpp
+++ b/src/gui/ExecuteSqlFrame.cpp
@@ -2101,15 +2101,15 @@ void ExecuteSqlFrame::OnMenuUpdateGridCanSetFieldToNULL(wxUpdateUIEvent& event)
 {
     // Issue #390: avoid the expensive getColumnsWithSelectedCells() call
     // here. The set-to-NULL menu item just needs to know "is at least one
-    // column writable" — that is a property of the underlying statement
-    // and is independent of how many rows are selected. The actual command
-    // re-validates per cell when invoked.
+    // column writable AND nullable" — both are properties of the
+    // underlying statement and independent of how many rows are selected.
+    // The actual command re-validates per cell when invoked.
     if (DataGridTable* dgt = grid_data->getDataGridTable())
     {
         int cols = grid_data->GetNumberCols();
         for (int i = 0; i < cols; ++i)
         {
-            if (!dgt->isReadonlyColumn(i))
+            if (!dgt->isReadonlyColumn(i) && dgt->isNullableColumn(i))
             {
                 event.Enable(true);
                 return;

--- a/src/gui/ExecuteSqlFrame.cpp
+++ b/src/gui/ExecuteSqlFrame.cpp
@@ -2099,12 +2099,12 @@ void ExecuteSqlFrame::OnMenuUpdateGridCancelFetchAll(wxUpdateUIEvent& event)
 
 void ExecuteSqlFrame::OnMenuUpdateGridCanSetFieldToNULL(wxUpdateUIEvent& event)
 {
-    // Issue #390: avoid the expensive getColumnsWithSelectedCells() call
-    // here. The set-to-NULL menu item just needs to know "is at least one
-    // column writable AND nullable" — both are properties of the
-    // underlying statement and independent of how many rows are selected.
-    // The actual command re-validates per cell when invoked.
-    if (DataGridTable* dgt = grid_data->getDataGridTable())
+    // The set-to-NULL menu item needs the grid to have data AND at least
+    // one column that is both writable and nullable. The selection itself
+    // is not inspected here — that lookup is expensive, and the actual
+    // command re-validates per cell when invoked.
+    DataGridTable* dgt = grid_data->getDataGridTable();
+    if (dgt && grid_data->GetNumberRows() > 0)
     {
         int cols = grid_data->GetNumberCols();
         for (int i = 0; i < cols; ++i)

--- a/src/gui/ExecuteSqlFrame.cpp
+++ b/src/gui/ExecuteSqlFrame.cpp
@@ -2099,21 +2099,21 @@ void ExecuteSqlFrame::OnMenuUpdateGridCancelFetchAll(wxUpdateUIEvent& event)
 
 void ExecuteSqlFrame::OnMenuUpdateGridCanSetFieldToNULL(wxUpdateUIEvent& event)
 {
+    // Issue #390: avoid the expensive getColumnsWithSelectedCells() call
+    // here. The set-to-NULL menu item just needs to know "is at least one
+    // column writable" — that is a property of the underlying statement
+    // and is independent of how many rows are selected. The actual command
+    // re-validates per cell when invoked.
     if (DataGridTable* dgt = grid_data->getDataGridTable())
     {
-        std::vector<bool> selCols(grid_data->getColumnsWithSelectedCells());
-        for (size_t i = 0; i < selCols.size(); i++)
+        int cols = grid_data->GetNumberCols();
+        for (int i = 0; i < cols; ++i)
         {
-            if (selCols[i] && !dgt->isReadonlyColumn(i))
+            if (!dgt->isReadonlyColumn(i))
             {
                 event.Enable(true);
                 return;
             }
-        }
-        if (!dgt->isReadonlyColumn(grid_data->GetGridCursorRow()))
-        {
-            event.Enable(true);
-            return;
         }
     }
     event.Enable(false);
@@ -3070,20 +3070,21 @@ void ExecuteSqlFrame::OnMenuUpdateGridDeleteRow(wxUpdateUIEvent& event)
         return;
     }
 
-    bool colsSelected = grid_data->GetSelectedCols().GetCount() > 0;
-    bool deletableRows = false;
-
-    if (!colsSelected)
-    {
-        wxArrayInt selRows(getSelectedGridRows(grid_data));
-        for (size_t i = 0; !deletableRows && i < selRows.GetCount(); ++i)
-        {
-            if (tb->canRemoveRow(selRows[i]))
-                deletableRows = true;
-        }
-    }
-
-    event.Enable(!colsSelected && deletableRows);
+    // Issue #390: this update handler runs for every menu item every
+    // time wxGrid emits a UI update (including before showing the
+    // context menu). The previous implementation built a full
+    // wxArrayInt of every selected row index via getSelectedGridRows()
+    // and then per-row canRemoveRow() calls — with 100k+ selected
+    // rows the menu took 8 seconds to appear (300k → ~115s).
+    //
+    // canRemoveRow(0) answers "does the underlying statement support
+    // row deletion at all" in O(1) (it's a property of the SQL, not
+    // the selection, and is cached after the first call). The real
+    // delete handler re-validates per row before deleting, so it is
+    // safe to use that cheap probe here. This also resolves the
+    // #444 case where Ctrl+A previously disabled the menu item
+    // because both rows AND columns were reported as selected.
+    event.Enable(tb->canRemoveRow(0));
 }
 
 void ExecuteSqlFrame::OnGridCellChange(wxGridEvent& event)


### PR DESCRIPTION
## Summary
Closes #390. Also closes #444 (and supersedes #526).

The reporter sees the right-click context menu take 8s with 100k rows selected, 50s at 200k, 115s at 300k — and the same delay again when the menu closes. With wxGrid's `wxEVT_UPDATE_UI` events firing for every menu item, two handlers were doing real work in the hot path:

- **`OnMenuUpdateGridDeleteRow`** built a `wxArrayInt` of every selected row index via `getSelectedGridRows()` (which materialises one entry per selected row, even for a single block), then called `canRemoveRow` per row.
- **`OnMenuUpdateGridCanSetFieldToNULL`** called `getColumnsWithSelectedCells()` which can iterate every individually-selected cell.

Both are showing-the-menu probes, not the actual destructive operation — they only need to answer "should the menu item be enabled at all". That question depends on the statement's writable columns and removable-row property, both O(1) and independent of the selection size. Switch to those cheap probes; the actual delete / set-NULL handlers continue to re-validate per row when invoked.

This also resolves #444 as a side-effect: the new path ignores the wxGrid quirk where Ctrl+A reports both rows AND columns selected simultaneously, which previously disabled the Delete-row menu item.

## Test plan
- [ ] Run a SELECT returning 300k+ rows
- [ ] Ctrl+A to select all, right-click → context menu appears instantly (was 115s)
- [ ] Close menu — no extra delay (previously the same 115s)
- [ ] Delete row(s) menu item is enabled
- [ ] Read-only result set (e.g. multi-table join) correctly disables Delete row(s) and Set field to NULL
- [ ] Original Delete and SetNull operations still work correctly when invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)