### PR TITLE
Implement #451: pre-fill SYSDBA username and focus first empty field

### DIFF
--- a/src/gui/DatabaseRegistrationDialog.cpp
+++ b/src/gui/DatabaseRegistrationDialog.cpp
@@ -405,13 +405,11 @@ void DatabaseRegistrationDialog::setDatabase(DatabasePtr db)
     updateButtons();
     updateColors();
 
-    // Issue #451 follow-up: focus the first empty editable field so the
-    // user can start typing immediately on dialog open. Order:
-    // database path → password. The username branch was removed after
-    // the SYSDBA pre-fill above made it permanently non-empty (Gemini
-    // review noted the dead branch); for the password we now also check
-    // emptiness so an editable-but-already-filled password field doesn't
-    // steal focus.
+    // Focus the first empty editable field so the user can start typing
+    // immediately on dialog open. The username field is always non-empty
+    // here (the SYSDBA pre-fill above), so it is skipped. The password
+    // emptiness check prevents an already-populated password field from
+    // stealing focus from the path field.
     if (text_ctrl_dbpath->IsEditable() && text_ctrl_dbpath->GetValue().IsEmpty())
         text_ctrl_dbpath->SetFocus();
     else if (text_ctrl_password->IsEditable() && text_ctrl_password->GetValue().IsEmpty())

--- a/src/gui/DatabaseRegistrationDialog.cpp
+++ b/src/gui/DatabaseRegistrationDialog.cpp
@@ -407,12 +407,14 @@ void DatabaseRegistrationDialog::setDatabase(DatabasePtr db)
 
     // Issue #451 follow-up: focus the first empty editable field so the
     // user can start typing immediately on dialog open. Order:
-    // database path → username → password.
+    // database path → password. The username branch was removed after
+    // the SYSDBA pre-fill above made it permanently non-empty (Gemini
+    // review noted the dead branch); for the password we now also check
+    // emptiness so an editable-but-already-filled password field doesn't
+    // steal focus.
     if (text_ctrl_dbpath->IsEditable() && text_ctrl_dbpath->GetValue().IsEmpty())
         text_ctrl_dbpath->SetFocus();
-    else if (text_ctrl_username->IsEditable() && text_ctrl_username->GetValue().IsEmpty())
-        text_ctrl_username->SetFocus();
-    else if (text_ctrl_password->IsEditable())
+    else if (text_ctrl_password->IsEditable() && text_ctrl_password->GetValue().IsEmpty())
         text_ctrl_password->SetFocus();
 }
 

--- a/src/gui/DatabaseRegistrationDialog.cpp
+++ b/src/gui/DatabaseRegistrationDialog.cpp
@@ -357,7 +357,15 @@ void DatabaseRegistrationDialog::setDatabase(DatabasePtr db)
     */
     text_ctrl_name->SetValue(databaseM->getName_());
     text_ctrl_dbpath->SetValue(databaseM->getPath());
-    text_ctrl_username->SetValue(databaseM->getUsername());
+    // Issue #451: pre-fill the username with the universally-default
+    // SYSDBA when the database has no saved value yet. We deliberately
+    // do NOT pre-fill the password — modern Firebird installs (FB 2+ on
+    // Posix, FB 3+ on Windows) prompt for an admin password during setup,
+    // so the legacy "masterkey" default is rarely correct anymore.
+    wxString savedUsername = databaseM->getUsername();
+    if (savedUsername.IsEmpty())
+        savedUsername = "SYSDBA";
+    text_ctrl_username->SetValue(savedUsername);
     text_ctrl_password->SetValue(databaseM->getDecryptedPassword());
     text_ctrl_role->SetValue(databaseM->getRole());
     text_ctrl_keydata->SetValue(databaseM->getCryptKeyData());
@@ -396,6 +404,16 @@ void DatabaseRegistrationDialog::setDatabase(DatabasePtr db)
     updateAuthenticationMode();
     updateButtons();
     updateColors();
+
+    // Issue #451 follow-up: focus the first empty editable field so the
+    // user can start typing immediately on dialog open. Order:
+    // database path → username → password.
+    if (text_ctrl_dbpath->IsEditable() && text_ctrl_dbpath->GetValue().IsEmpty())
+        text_ctrl_dbpath->SetFocus();
+    else if (text_ctrl_username->IsEditable() && text_ctrl_username->GetValue().IsEmpty())
+        text_ctrl_username->SetFocus();
+    else if (text_ctrl_password->IsEditable())
+        text_ctrl_password->SetFocus();
 }
 
 void DatabaseRegistrationDialog::suggestDefaultPageSizeByServerVersion()


### PR DESCRIPTION
## Summary
Closes #451.

Pre-fill the username field with **SYSDBA** when the database has no saved value yet — the universally-correct default. Per the issue's discussion, **do not** pre-fill the password: modern Firebird installs (FB 2+ on Posix, FB 3+ on Windows) prompt for an admin password at install time, so the legacy *masterkey* default is rarely correct anymore and could mislead users into trying it on production servers.

Also focus the first empty editable field on dialog open (database path → username → password) so the user can start typing immediately, addressing the follow-up comment on the issue.

## Test plan
- [ ] Open Database → Register existing database… → username field shows "SYSDBA" by default
- [ ] Database path field has focus on open
- [ ] Editing an existing database with a saved non-default username preserves that value (not overwritten)
- [ ] Password field is never pre-filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)