### PR TITLE
Implement #214: align suggested index name pattern with FB convention

### DIFF
--- a/src/gui/CreateIndexDialog.cpp
+++ b/src/gui/CreateIndexDialog.cpp
@@ -115,32 +115,44 @@ void CreateIndexDialog::setControlsProperties()
     int nr = 1;
     std::vector<Index>* indices = tableM->getIndices();
 
-    // Issue #214: include an underscore between the table name and the
-    // sequence number so the suggested name matches the convention
-    // Firebird itself uses for auto-named PK/FK/UNIQUE/CHECK constraints
+    // Include an underscore between the table name and the sequence
+    // number so the suggested name matches the convention Firebird
+    // itself uses for auto-named PK/FK/UNIQUE/CHECK constraints
     // (e.g. IDX_FB3_TEST_1 instead of IDX_FB3_TEST1).
     //
-    // Gemini-flagged caveat: object identifiers are limited to 31 bytes
-    // on Firebird < 4.0 (FB 4 raised it to 63). For long table names the
-    // extra underscore can push the suggestion over that limit, which
-    // would surface as a server-side ALTER error. Truncate the table-name
-    // portion of the suggestion if needed so the assembled name still
-    // fits the maximum the connected ODS supports. Existing indexes (if
-    // the truncated name collides with one) cause the loop below to bump
-    // the sequence number, same as before.
+    // Object identifiers are limited to 31 BYTES on Firebird < 4.0 and
+    // 63 bytes on FB 4+ (ODS 13). Bytes, not characters — for non-ASCII
+    // table names a single character may take multiple bytes in the
+    // database's metadata charset, so size with the connection's
+    // character set converter rather than wxString::length(). Truncate
+    // the table-name portion of the suggestion if needed so the
+    // assembled name still fits the maximum the connected ODS supports.
     int maxIdLen = 31;
     DatabasePtr db = tableM->getDatabase();
     if (db && db->getInfo().getODSVersionIsHigherOrEqualTo(13, 0))
         maxIdLen = 63;     // Firebird 4+ (ODS 13.0)
+    wxMBConv* conv = db ? db->getCharsetConverter() : &wxConvCurrent;
 
     while (indexName.IsEmpty())
     {
-        // Reserve room for "IDX_", the underscore, and the sequence digits.
+        // Reserve room for "IDX_", the underscore, and the sequence
+        // digits — those are all single-byte ASCII so byte length and
+        // character length are equivalent for the prefix/suffix.
         wxString seq = wxString::Format("%d", nr);
         int reserved = 4 /* "IDX_" */ + 1 /* "_" */ + (int)seq.length();
+        int budget = maxIdLen - reserved;
+        if (budget < 0) budget = 0;
+
         wxString tableName = tableM->getName_();
-        if ((int)tableName.length() > maxIdLen - reserved)
-            tableName = tableName.Left(maxIdLen - reserved);
+        // Trim character-by-character from the right until the encoded
+        // byte length fits the remaining budget. For ASCII names this
+        // is one check; for multi-byte charsets it converges in a
+        // handful of iterations.
+        while (!tableName.IsEmpty() &&
+            tableName.mb_str(*conv).length() > static_cast<size_t>(budget))
+        {
+            tableName.Truncate(tableName.length() - 1);
+        }
 
         indexName = "IDX_" + tableName + "_" + seq;
         nr++;

--- a/src/gui/CreateIndexDialog.cpp
+++ b/src/gui/CreateIndexDialog.cpp
@@ -116,7 +116,11 @@ void CreateIndexDialog::setControlsProperties()
     std::vector<Index>* indices = tableM->getIndices();
     while (indexName.IsEmpty())
     {
-        indexName = wxString::Format("IDX_%s%d",
+        // Issue #214: include the underscore between table name and
+        // sequence so the suggested name matches the convention Firebird
+        // itself uses for auto-named PK/FK/UNIQUE/CHECK constraints
+        // (e.g. IDX_FB3_TEST_1 instead of IDX_FB3_TEST1).
+        indexName = wxString::Format("IDX_%s_%d",
             tableM->getName_().c_str(), nr++);
         std::vector<Index>::iterator itIdx;
         for (itIdx = indices->begin(); itIdx != indices->end(); ++itIdx)

--- a/src/gui/CreateIndexDialog.cpp
+++ b/src/gui/CreateIndexDialog.cpp
@@ -113,6 +113,7 @@ void CreateIndexDialog::setControlsProperties()
     // suggest name for new index
     wxString indexName;
     int nr = 1;
+    std::vector<Index>* indices = tableM->getIndices();
 
     // Issue #214: include an underscore between the table name and the
     // sequence number so the suggested name matches the convention

--- a/src/gui/CreateIndexDialog.cpp
+++ b/src/gui/CreateIndexDialog.cpp
@@ -113,15 +113,37 @@ void CreateIndexDialog::setControlsProperties()
     // suggest name for new index
     wxString indexName;
     int nr = 1;
-    std::vector<Index>* indices = tableM->getIndices();
+
+    // Issue #214: include an underscore between the table name and the
+    // sequence number so the suggested name matches the convention
+    // Firebird itself uses for auto-named PK/FK/UNIQUE/CHECK constraints
+    // (e.g. IDX_FB3_TEST_1 instead of IDX_FB3_TEST1).
+    //
+    // Gemini-flagged caveat: object identifiers are limited to 31 bytes
+    // on Firebird < 4.0 (FB 4 raised it to 63). For long table names the
+    // extra underscore can push the suggestion over that limit, which
+    // would surface as a server-side ALTER error. Truncate the table-name
+    // portion of the suggestion if needed so the assembled name still
+    // fits the maximum the connected ODS supports. Existing indexes (if
+    // the truncated name collides with one) cause the loop below to bump
+    // the sequence number, same as before.
+    int maxIdLen = 31;
+    DatabasePtr db = tableM->getDatabase();
+    if (db && db->getInfo().getODSVersionIsHigherOrEqualTo(13, 0))
+        maxIdLen = 63;     // Firebird 4+ (ODS 13.0)
+
     while (indexName.IsEmpty())
     {
-        // Issue #214: include the underscore between table name and
-        // sequence so the suggested name matches the convention Firebird
-        // itself uses for auto-named PK/FK/UNIQUE/CHECK constraints
-        // (e.g. IDX_FB3_TEST_1 instead of IDX_FB3_TEST1).
-        indexName = wxString::Format("IDX_%s_%d",
-            tableM->getName_().c_str(), nr++);
+        // Reserve room for "IDX_", the underscore, and the sequence digits.
+        wxString seq = wxString::Format("%d", nr);
+        int reserved = 4 /* "IDX_" */ + 1 /* "_" */ + (int)seq.length();
+        wxString tableName = tableM->getName_();
+        if ((int)tableName.length() > maxIdLen - reserved)
+            tableName = tableName.Left(maxIdLen - reserved);
+
+        indexName = "IDX_" + tableName + "_" + seq;
+        nr++;
+
         std::vector<Index>::iterator itIdx;
         for (itIdx = indices->begin(); itIdx != indices->end(); ++itIdx)
         {

--- a/src/gui/CreateIndexDialog.cpp
+++ b/src/gui/CreateIndexDialog.cpp
@@ -131,7 +131,7 @@ void CreateIndexDialog::setControlsProperties()
     DatabasePtr db = tableM->getDatabase();
     if (db && db->getInfo().getODSVersionIsHigherOrEqualTo(13, 0))
         maxIdLen = 63;     // Firebird 4+ (ODS 13.0)
-    wxMBConv* conv = db ? db->getCharsetConverter() : &wxConvCurrent;
+    wxMBConv* conv = db ? db->getCharsetConverter() : wxConvCurrent;
 
     while (indexName.IsEmpty())
     {


### PR DESCRIPTION
## Summary
Closes #214.

Suggested index names previously used `IDX_TABLENAME1` (no underscore between table name and sequence number), inconsistent with the underscore-separated names Firebird auto-generates for PK / FK / UNIQUE / CHECK constraints (e.g. `FK_FB3_TEST_1`).

Add the underscore so the suggestion comes out as `IDX_TABLENAME_1`, matching every other constraint in the same database. Reporter and a second commenter both voted for this form. Existing indexes are unaffected — only the default suggestion when creating a new one.

A fully-configurable pattern (e.g. `TABLENAME_IDX_n` instead of `IDX_TABLENAME_n`) would be a larger change involving Preferences UI; this PR is the minimal alignment fix from the issue.

## Test plan
- [ ] Open a table, Create new index → name field shows `IDX_TABLENAME_1` (was `IDX_TABLENAME1`)
- [ ] If `IDX_TABLENAME_1` already exists, the suggestion correctly increments to `_2`, `_3`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)