### PR TITLE
Implement #238: configurable defaults for database registration fields

### DIFF
--- a/conf-defs/fr_settings.confdef
+++ b/conf-defs/fr_settings.confdef
@@ -162,6 +162,28 @@
             <default>0</default>
         </setting>
     </node>
+    <node>
+        <caption>Database Registration Defaults</caption>
+        <image>3</image>
+        <setting type="string">
+            <caption>Default user name:</caption>
+            <description>Pre-fill the user name field when registering or creating a database. Leave blank for no default.</description>
+            <key>databaseDefaultUsername</key>
+            <default>SYSDBA</default>
+        </setting>
+        <setting type="string">
+            <caption>Default character set:</caption>
+            <description>Pre-fill the character set field when registering or creating a database. Common choices: NONE, UTF8, ISO8859_1.</description>
+            <key>databaseDefaultCharset</key>
+            <default>NONE</default>
+        </setting>
+        <setting type="string">
+            <caption>Default role:</caption>
+            <description>Pre-fill the role field when registering or creating a database. Leave blank for no default.</description>
+            <key>databaseDefaultRole</key>
+            <default></default>
+        </setting>
+    </node>
 	<node>
         <caption>Transaction Settings</caption>
         <image>0</image>

--- a/src/gui/DatabaseRegistrationDialog.cpp
+++ b/src/gui/DatabaseRegistrationDialog.cpp
@@ -385,8 +385,17 @@ void DatabaseRegistrationDialog::setDatabase(DatabasePtr db)
     text_ctrl_library->SetValue(databaseM->getClientLibrary());
     */
     wxString charset(databaseM->getConnectionCharset());
-    if (isNewRegistration && charset.IsEmpty())
-        charset = config().get("databaseDefaultCharset", wxString("NONE"));
+    if (charset.IsEmpty())
+    {
+        // For a new registration, prefer the user-configured default
+        // (which itself defaults to "NONE"). For an existing entry with
+        // an empty stored charset, preserve the original UI behaviour
+        // of showing "NONE" so the combobox isn't blank — that was the
+        // visible default before the configurable default existed.
+        charset = isNewRegistration
+            ? config().get("databaseDefaultCharset", wxString("NONE"))
+            : wxString("NONE");
+    }
     combobox_charset->SetValue(charset);
     if (createM)
         suggestDefaultPageSizeByServerVersion();

--- a/src/gui/DatabaseRegistrationDialog.cpp
+++ b/src/gui/DatabaseRegistrationDialog.cpp
@@ -357,9 +357,18 @@ void DatabaseRegistrationDialog::setDatabase(DatabasePtr db)
     */
     text_ctrl_name->SetValue(databaseM->getName_());
     text_ctrl_dbpath->SetValue(databaseM->getPath());
-    text_ctrl_username->SetValue(databaseM->getUsername());
+    // Issue #238: read default username / charset / role from config so
+    // the user does not have to retype them for every new registration.
+    // Saved-per-database values still take precedence.
+    wxString savedUsername = databaseM->getUsername();
+    if (savedUsername.IsEmpty())
+        savedUsername = config().get("databaseDefaultUsername", wxString("SYSDBA"));
+    text_ctrl_username->SetValue(savedUsername);
     text_ctrl_password->SetValue(databaseM->getDecryptedPassword());
-    text_ctrl_role->SetValue(databaseM->getRole());
+    wxString savedRole = databaseM->getRole();
+    if (savedRole.IsEmpty())
+        savedRole = config().get("databaseDefaultRole", wxString());
+    text_ctrl_role->SetValue(savedRole);
     text_ctrl_keydata->SetValue(databaseM->getCryptKeyData());
     /*
     * Todo: Implement FB library per conexion
@@ -367,7 +376,7 @@ void DatabaseRegistrationDialog::setDatabase(DatabasePtr db)
     */
     wxString charset(databaseM->getConnectionCharset());
     if (charset.empty())
-        charset = "NONE";
+        charset = config().get("databaseDefaultCharset", wxString("NONE"));
     combobox_charset->SetValue(charset);
     if (createM)
         suggestDefaultPageSizeByServerVersion();

--- a/src/gui/DatabaseRegistrationDialog.cpp
+++ b/src/gui/DatabaseRegistrationDialog.cpp
@@ -360,13 +360,23 @@ void DatabaseRegistrationDialog::setDatabase(DatabasePtr db)
     // Issue #238: read default username / charset / role from config so
     // the user does not have to retype them for every new registration.
     // Saved-per-database values still take precedence.
+    //
+    // Gemini-flagged: only apply defaults to NEW registrations. The
+    // database path is the load-bearing field — it is empty for a
+    // fresh "Register existing database" / "Create new database" /
+    // "Connect as" dialog and non-empty when editing a saved entry.
+    // Without this gate, opening an existing entry that intentionally
+    // has an empty username (e.g. trusted-auth) would silently rewrite
+    // it to the configured default on the next Save.
+    bool isNewRegistration = databaseM->getPath().IsEmpty();
+
     wxString savedUsername = databaseM->getUsername();
-    if (savedUsername.IsEmpty())
+    if (isNewRegistration && savedUsername.IsEmpty())
         savedUsername = config().get("databaseDefaultUsername", wxString("SYSDBA"));
     text_ctrl_username->SetValue(savedUsername);
     text_ctrl_password->SetValue(databaseM->getDecryptedPassword());
     wxString savedRole = databaseM->getRole();
-    if (savedRole.IsEmpty())
+    if (isNewRegistration && savedRole.IsEmpty())
         savedRole = config().get("databaseDefaultRole", wxString());
     text_ctrl_role->SetValue(savedRole);
     text_ctrl_keydata->SetValue(databaseM->getCryptKeyData());
@@ -375,7 +385,7 @@ void DatabaseRegistrationDialog::setDatabase(DatabasePtr db)
     text_ctrl_library->SetValue(databaseM->getClientLibrary());
     */
     wxString charset(databaseM->getConnectionCharset());
-    if (charset.empty())
+    if (isNewRegistration && charset.IsEmpty())
         charset = config().get("databaseDefaultCharset", wxString("NONE"));
     combobox_charset->SetValue(charset);
     if (createM)

--- a/src/gui/DatabaseRegistrationDialog.cpp
+++ b/src/gui/DatabaseRegistrationDialog.cpp
@@ -361,13 +361,13 @@ void DatabaseRegistrationDialog::setDatabase(DatabasePtr db)
     // the user does not have to retype them for every new registration.
     // Saved-per-database values still take precedence.
     //
-    // Gemini-flagged: only apply defaults to NEW registrations. The
-    // database path is the load-bearing field — it is empty for a
-    // fresh "Register existing database" / "Create new database" /
-    // "Connect as" dialog and non-empty when editing a saved entry.
-    // Without this gate, opening an existing entry that intentionally
-    // has an empty username (e.g. trusted-auth) would silently rewrite
-    // it to the configured default on the next Save.
+    // Only apply defaults to NEW registrations. The database path is the
+    // load-bearing field — it is empty for a fresh "Register existing
+    // database" / "Create new database" / "Connect as" dialog and non-
+    // empty when editing a saved entry. Without this gate, opening an
+    // existing entry that intentionally has an empty username (e.g.
+    // trusted-auth) would silently rewrite it to the configured default
+    // on the next Save.
     bool isNewRegistration = databaseM->getPath().IsEmpty();
 
     wxString savedUsername = databaseM->getUsername();


### PR DESCRIPTION
## Summary
Closes #238.

Adds three new Preferences settings under a *Database Registration Defaults* page so users do not have to retype the same username, charset, and role for every newly registered database:

- **databaseDefaultUsername** (default: \`SYSDBA\`)
- **databaseDefaultCharset** (default: \`NONE\`)
- **databaseDefaultRole** (default: empty)

Defaults are read from config in \`DatabaseRegistrationDialog::setDatabase\`, but only when the database itself has no saved value — so editing an existing database with a non-default username, charset, or role preserves that database's setting.

The password field is intentionally **not** pre-filled. Modern Firebird installs (FB 2+ on Posix, FB 3+ on Windows) prompt for an admin password at install time, so the legacy *masterkey* default is rarely correct anymore and pre-filling it would be a security footgun.

Note: this overlaps with #529 (which hardcodes SYSDBA + adds focus management). Either can land first; the rebase against the other is mechanical.

## Test plan
- [ ] Open Preferences → Database Registration Defaults — three string settings appear with sensible defaults
- [ ] Set custom default charset (e.g. UTF8) → next time you register a new database, charset combobox is pre-filled to UTF8
- [ ] Editing an existing registered database with a saved non-default value preserves that value
- [ ] Setting default to empty string disables pre-fill (verified by leaving role blank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)