### PR TITLE
Implement #189: consistent default + clearer description for keyword case

### DIFF
--- a/conf-defs/fr_settings.confdef
+++ b/conf-defs/fr_settings.confdef
@@ -538,6 +538,7 @@
         <image>5</image>
         <setting type="checkbox">
             <caption>Use UPPER CASE keywords</caption>
+            <description>Show SQL keywords in upper case in code completion suggestions, in highlighted SQL, and in generated DDL/DML. Identifiers (table, column, procedure names) always retain their actual case from the database.</description>
             <key>SQLKeywordsUpperCase</key>
             <default>1</default>
         </setting>

--- a/src/gui/controls/DBHTreeControl.cpp
+++ b/src/gui/controls/DBHTreeControl.cpp
@@ -143,7 +143,7 @@ void DBHTreeConfigCache::loadFromConfig()
     changes += setValue(showDomainsM,
         cfg.get("ShowDomains", 2));
     changes += setValue(sqlKeywordsUpperCaseM,
-        cfg.get("SQLKeywordsUpperCase", false));
+        cfg.get("SQLKeywordsUpperCase", true));
 
     if (changes)
         notifyObservers();

--- a/src/sql/SqlTokenizer.cpp
+++ b/src/sql/SqlTokenizer.cpp
@@ -183,9 +183,9 @@ wxArrayString SqlTokenizer::getKeywords(KeywordCase kwc, int odsMajor,
         getKeywordSetForVersion(version.major));
     keywords.Alloc(keywordSet.keywordsCount);
 
-    // Use the cached config value (Gemini feedback) so we do not hit the
-    // config map on every getKeywords call. The cache invalidates itself
-    // when the user changes the setting in Preferences.
+    // Use the cached config value so we do not hit the config map on
+    // every getKeywords call. The cache invalidates itself when the
+    // user changes the setting in Preferences.
     bool upperCase = (kwc == kwUpperCase) || (kwc == kwDefaultCase
         && SqlTokenizerConfigCache::get().getSqlKeywordsUpperCase());
     for (size_t i = 0; i < keywordSet.keywordsCount; ++i)

--- a/src/sql/SqlTokenizer.cpp
+++ b/src/sql/SqlTokenizer.cpp
@@ -44,7 +44,7 @@ protected:
     virtual void loadFromConfig()
     {
         sqlKeywordsUpperCaseM = config().get("SQLKeywordsUpperCase",
-            false);
+            true);
     }
 public:
     SqlTokenizerConfigCache() : ConfigCache(config()) {}
@@ -184,7 +184,7 @@ wxArrayString SqlTokenizer::getKeywords(KeywordCase kwc, int odsMajor,
     keywords.Alloc(keywordSet.keywordsCount);
 
     bool upperCase = (kwc == kwUpperCase) || (kwc == kwDefaultCase
-        && config().get("SQLKeywordsUpperCase", false));
+        && config().get("SQLKeywordsUpperCase", true));
     for (size_t i = 0; i < keywordSet.keywordsCount; ++i)
     {
         appendCaseKeyword(keywords, keywordSet.keywords[i], upperCase);

--- a/src/sql/SqlTokenizer.cpp
+++ b/src/sql/SqlTokenizer.cpp
@@ -183,8 +183,11 @@ wxArrayString SqlTokenizer::getKeywords(KeywordCase kwc, int odsMajor,
         getKeywordSetForVersion(version.major));
     keywords.Alloc(keywordSet.keywordsCount);
 
+    // Use the cached config value (Gemini feedback) so we do not hit the
+    // config map on every getKeywords call. The cache invalidates itself
+    // when the user changes the setting in Preferences.
     bool upperCase = (kwc == kwUpperCase) || (kwc == kwDefaultCase
-        && config().get("SQLKeywordsUpperCase", true));
+        && SqlTokenizerConfigCache::get().getSqlKeywordsUpperCase());
     for (size_t i = 0; i < keywordSet.keywordsCount; ++i)
     {
         appendCaseKeyword(keywords, keywordSet.keywords[i], upperCase);


### PR DESCRIPTION
## Summary
Closes #189.

The *Use UPPER CASE keywords* Preference (\`SQLKeywordsUpperCase\`) is already exposed and already drives both code completion and generated SQL — but two issues made it confusing:

**1. Inconsistent in-code defaults.** The confdef defaults the value to \`1\`, and \`StatementBuilder\` / \`TemplateProcessor\` read it with default \`true\`. But \`SqlTokenizer\` (line 187) and \`DBHTreeControl\` read it with default \`false\`. On the rare occasion where the config key isn't materialised (fresh \`fr_settings.conf\` read by these paths first), code completion offered lower-case keywords while the rest of the app emitted upper-case — exactly the asymmetry the reporter described. Made all defaults \`true\` so the visible behavior matches the confdef.

**2. The setting had no description.** The reporter's refined comment on the issue clarified what they wanted: keywords UPPER, identifiers in their actual database case. The code already does exactly that (identifiers come from \`databaseM->getIdentifiers\` in their stored case). Added a description making this explicit so users find the setting and know what it does.

## Test plan
- [ ] Fresh install (no fr_settings.conf yet): code completion suggests upper-case keywords (\`SELECT\`, \`FROM\`)
- [ ] Same install: identifier completion uses the database's actual casing for table / column names
- [ ] Toggling Preferences → SQL Statement Generation → "Use UPPER CASE keywords" off: completion suggests lower-case keywords
- [ ] Description text appears in the Preferences dialog explaining the scope of the setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)