### PR TITLE
Implement #450: move database registration to another server

### DIFF
--- a/src/gui/CommandIds.h
+++ b/src/gui/CommandIds.h
@@ -117,6 +117,7 @@ enum {
     Menu_DatabaseProperties,
     Menu_GenerateData,
     Menu_CloneDatabase,
+    Menu_MoveDatabaseToServer,
     Menu_ExecuteFunction,
     Menu_ShowStatisticsValue,
     Menu_SetStatisticsValue,

--- a/src/gui/ContextMenuMetadataItemVisitor.cpp
+++ b/src/gui/ContextMenuMetadataItemVisitor.cpp
@@ -107,6 +107,7 @@ void MainObjectMenuMetadataItemVisitor::visitDatabase(Database& database)
     menuM->Append(Cmds::Menu_DatabaseRegistrationInfo,
         _("Database registration &info"));
     menuM->Append(Cmds::Menu_CloneDatabase, _("C&lone registration info"));
+    menuM->Append(Cmds::Menu_MoveDatabaseToServer, _("&Move registration to server..."));
     menuM->Append(Cmds::Menu_UnRegisterDatabase, _("&Unregister database"));
     menuM->Append(Cmds::Menu_DatabasePreferences,
         _("Database &preferences"));

--- a/src/gui/MainFrame.cpp
+++ b/src/gui/MainFrame.cpp
@@ -1103,14 +1103,15 @@ void MainFrame::OnMenuMoveDatabaseToServer(wxCommandEvent& WXUNUSED(event))
         return;     // user cancelled
 
     ServerPtr target = serverChoices[idx];
-    // Wrap the move in a SubjectLocker on the Root so the tree control
-    // sees a single batched update instead of three separate refreshes
-    // (remove from current server, add to target server, save). Without
-    // it the tree was rebuilt three times for a single user action —
-    // perceptible flicker on large registration lists, and Gemini's PR
-    // review flagged the redundant refreshes.
+    // Batch the tree refreshes around the move. removeDatabase /
+    // addDatabase notifications are emitted by the Server objects (not
+    // by Root), so SubjectLockers on both source and target servers are
+    // what actually defer the tree rebuilds. Locking Root in addition
+    // covers the save() call.
     {
-        SubjectLocker lock(rootM.get());
+        SubjectLocker lockRoot(rootM.get());
+        SubjectLocker lockSource(currentServer.get());
+        SubjectLocker lockTarget(target.get());
         currentServer->removeDatabase(d);
         target->addDatabase(d);
         rootM->save();

--- a/src/gui/MainFrame.cpp
+++ b/src/gui/MainFrame.cpp
@@ -399,6 +399,8 @@ EVT_MENU(Cmds::Menu_GenerateData, MainFrame::OnMenuGenerateData)
 EVT_UPDATE_UI(Cmds::Menu_GenerateData, MainFrame::OnMenuUpdateIfDatabaseConnectedOrAutoConnect)
 EVT_MENU(Cmds::Menu_CloneDatabase, MainFrame::OnMenuCloneDatabase)
 EVT_UPDATE_UI(Cmds::Menu_CloneDatabase, MainFrame::OnMenuUpdateIfDatabaseSelected)
+EVT_MENU(Cmds::Menu_MoveDatabaseToServer, MainFrame::OnMenuMoveDatabaseToServer)
+EVT_UPDATE_UI(Cmds::Menu_MoveDatabaseToServer, MainFrame::OnMenuUpdateIfDatabaseSelected)
 EVT_MENU(Cmds::Menu_DatabaseRegistrationInfo, MainFrame::OnMenuDatabaseRegistrationInfo)
 EVT_UPDATE_UI(Cmds::Menu_DatabaseRegistrationInfo, MainFrame::OnMenuUpdateIfDatabaseSelected)
 EVT_MENU(Cmds::Menu_Backup, MainFrame::OnMenuBackup)
@@ -1052,6 +1054,58 @@ void MainFrame::OnMenuCloneDatabase(wxCommandEvent& WXUNUSED(event))
         rootM->save();
         treeMainM->selectMetadataItem(db.get());
     }
+}
+
+void MainFrame::OnMenuMoveDatabaseToServer(wxCommandEvent& WXUNUSED(event))
+{
+    // Issue #450: re-home a registered database under a different server,
+    // so users do not have to manually re-register identical databases on
+    // each newly-added server.
+    DatabasePtr d = getDatabase(treeMainM->getSelectedMetadataItem());
+    if (!checkValidDatabase(d))
+        return;
+    if (d->isConnected())
+    {
+        wxMessageBox(_("Disconnect the database before moving its registration."),
+            _("Cannot move connected database"), wxOK | wxICON_WARNING);
+        return;
+    }
+
+    ServerPtr currentServer = getServer(treeMainM->getSelectedMetadataItem());
+    if (!checkValidServer(currentServer))
+        return;
+
+    // Build the picker list of all OTHER registered servers.
+    ServerPtrs allServers = rootM->getServers();
+    wxArrayString serverNames;
+    std::vector<ServerPtr> serverChoices;
+    for (ServerPtrs::const_iterator it = allServers.begin();
+        it != allServers.end(); ++it)
+    {
+        if (*it == currentServer)
+            continue;
+        serverNames.Add((*it)->getName_() + " (" + (*it)->getHostname() + ")");
+        serverChoices.push_back(*it);
+    }
+    if (serverChoices.empty())
+    {
+        wxMessageBox(_("There are no other registered servers to move this "
+            "database to. Register another server first."),
+            _("No target server available"), wxOK | wxICON_INFORMATION);
+        return;
+    }
+
+    int idx = ::wxGetSingleChoiceIndex(
+        wxString::Format(_("Move \"%s\" to which server?"), d->getName_()),
+        _("Move registration to server"), serverNames, this);
+    if (idx == -1)
+        return;     // user cancelled
+
+    ServerPtr target = serverChoices[idx];
+    currentServer->removeDatabase(d);
+    target->addDatabase(d);
+    rootM->save();
+    treeMainM->selectMetadataItem(d.get());
 }
 
 void MainFrame::OnMenuDatabaseRegistrationInfo(wxCommandEvent& WXUNUSED(event))

--- a/src/gui/MainFrame.cpp
+++ b/src/gui/MainFrame.cpp
@@ -40,6 +40,7 @@
 #include "core/ArtProvider.h"
 #include "core/CodeTemplateProcessor.h"
 #include "core/FRError.h"
+#include "core/Subject.h"
 #include "core/URIProcessor.h"
 #include "frutils.h"
 #include "gui/AboutBox.h"
@@ -1102,9 +1103,18 @@ void MainFrame::OnMenuMoveDatabaseToServer(wxCommandEvent& WXUNUSED(event))
         return;     // user cancelled
 
     ServerPtr target = serverChoices[idx];
-    currentServer->removeDatabase(d);
-    target->addDatabase(d);
-    rootM->save();
+    // Wrap the move in a SubjectLocker on the Root so the tree control
+    // sees a single batched update instead of three separate refreshes
+    // (remove from current server, add to target server, save). Without
+    // it the tree was rebuilt three times for a single user action —
+    // perceptible flicker on large registration lists, and Gemini's PR
+    // review flagged the redundant refreshes.
+    {
+        SubjectLocker lock(rootM.get());
+        currentServer->removeDatabase(d);
+        target->addDatabase(d);
+        rootM->save();
+    }
     treeMainM->selectMetadataItem(d.get());
 }
 

--- a/src/gui/MainFrame.h
+++ b/src/gui/MainFrame.h
@@ -60,6 +60,7 @@ public:
     void OnMenuNewVolatileSQLEditor(wxCommandEvent& event);
     void OnMenuRegisterDatabase(wxCommandEvent& event);
     void OnMenuCloneDatabase(wxCommandEvent& event);
+    void OnMenuMoveDatabaseToServer(wxCommandEvent& event);
     void OnMenuDatabaseRegistrationInfo(wxCommandEvent& event);
     void OnMenuCreateDatabase(wxCommandEvent& event);
     void OnMenuRecreateDatabase(wxCommandEvent& event);


### PR DESCRIPTION
## Summary
Closes #450.

Adds a *Move registration to server…* entry to the database context menu. Selecting it pops up a server picker (excluding the current server); on OK the registration is detached from the current server and re-attached to the chosen one, then saved.

The use case from the issue: 100+ servers each hosting the same set of databases. Today users must re-register identical entries by hand on every server (or use *Clone* followed by manual edits). With this command the existing registration — display name, path, credentials, charset, role, key data — is preserved and just re-homed.

Connected databases must be disconnected first; the handler shows a warning rather than tearing down a live connection. If only one server is registered, it shows an informational dialog instead of an empty picker.

The issue also mentioned cut/copy/paste of registrations as a more flexible alternative — that pattern would require an internal clipboard plus a paste target on server nodes. This PR addresses the primary use case (move) with the minimal UI; cut/copy/paste can be a follow-up if there is demand.

## Test plan
- [ ] Right-click a registered (disconnected) database → "Move registration to server..." appears
- [ ] Picker shows every other registered server, formatted as \`name (hostname)\`
- [ ] Choosing one moves the database under that server in the tree, the entry remains selected, and reopening FlameRobin still shows it under the new server
- [ ] If the database is currently connected, a warning appears and the move is aborted
- [ ] If there is only one registered server, an informational message appears instead of an empty picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)