### PR TITLE
Adapt HTML metadata views to system dark mode

### DIFF
--- a/src/gui/FRStyle.cpp
+++ b/src/gui/FRStyle.cpp
@@ -33,6 +33,7 @@
 #include <algorithm>
 
 #include "wx/filename.h"
+#include "wx/settings.h"
 #include "wx/xml/xml.h"
 
 #include "FRStyle.h"
@@ -186,11 +187,22 @@ void FRStyle::write2Element(wxXmlNode* element)
 
 wxFont FRStyle::getFont()
 {
-    wxFontInfo fontInfo(getFontSize());
+    // The XML style defines fontSize as a string and may leave it empty
+    // (parsed as STYLE_NOT_USED == -1). Passing a negative size to
+    // wxFontInfo produces a barely-readable tiny font on macOS — pick the
+    // system default font size instead so labels and grid cells stay
+    // legible. Same goes for an empty fontName.
+    int size = getFontSize();
+    if (size <= 0)
+    {
+        wxFont sys = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
+        size = sys.GetPointSize();
+    }
+    wxFontInfo fontInfo(size);
 
-    if (!getFontName().IsEmpty()) 
+    if (!getFontName().IsEmpty())
         fontInfo.FaceName(getFontName());
-    
+
     fontInfo.Bold(getFontStyle() & FONTSTYLE_BOLD);
     fontInfo.Italic(getFontStyle() & FONTSTYLE_ITALIC);
     fontInfo.Underlined(getFontStyle() & FONTSTYLE_UNDERLINE);

--- a/src/gui/FRStyleManager.cpp
+++ b/src/gui/FRStyleManager.cpp
@@ -170,6 +170,8 @@ void FRStyleManager::assignGlobal(wxStyledTextCtrl* text)
 {
     //text->StyleClearAll();
 
+    FRStyle* globalOverrideStyle = nullptr;
+
     for (int i = 0; i < globalStylerM->getNbStyler(); i++) {
         FRStyle* style = globalStylerM->getStyle(i);
         //if (style->getStyleID() != 0) {
@@ -177,6 +179,7 @@ void FRStyleManager::assignGlobal(wxStyledTextCtrl* text)
         //}
         if (style->getStyleDesc() == "Global override") {
             //globalStyleM = style;
+            globalOverrideStyle = style;
             text->StyleResetDefault();
             text->SetBackgroundColour(style->getbgColor());
             text->SetForegroundColour(style->getfgColor());
@@ -224,6 +227,20 @@ void FRStyleManager::assignGlobal(wxStyledTextCtrl* text)
         }
     }
 
+    // Many WidgetStyle entries in the theme XMLs reuse styleID="0" even
+    // though they only configure widget-level properties (caret line,
+    // selection bg, edge, fold). Each iteration above blindly calls
+    // assignWordStyle, so style slot 0 ends up holding whichever entry
+    // was iterated last (often a near-white selection or current-line
+    // colour). On dark themes that surfaces as light blocks behind every
+    // unstyled token. Re-apply Global override last and propagate it to
+    // every style slot via StyleClearAll so unset lexer styles inherit a
+    // sensible background instead of Scintilla's hard-coded white.
+    if (globalOverrideStyle != nullptr) {
+        text->StyleSetBackground(wxSTC_STYLE_DEFAULT, globalOverrideStyle->getbgColor());
+        text->StyleSetForeground(wxSTC_STYLE_DEFAULT, globalOverrideStyle->getfgColor());
+        text->StyleClearAll();
+    }
 }
 
 void FRStyleManager::assignLexer(wxStyledTextCtrl* text)

--- a/src/gui/FRStyleManager.cpp
+++ b/src/gui/FRStyleManager.cpp
@@ -28,6 +28,7 @@
 // need because it includes almost all "standard" wxWindows headers
 #ifndef WX_PRECOMP
 #include "wx/wx.h"
+#include "wx/settings.h"
 #endif
 
 #include <algorithm>
@@ -314,17 +315,25 @@ void FRStyleManager::assignMargin(wxStyledTextCtrl* text)
 
 void FRStyleManager::loadConfig()
 {
+    // If no theme has been picked yet, fall back to the dark-mode default
+    // when the system is in dark mode so the SQL editor and data grid don't
+    // render as a bright white panel inside an otherwise dark window. The
+    // user's explicit Preferences choice still wins.
+    const wxString systemDefault =
+        wxSystemSettings::GetAppearance().IsDark()
+            ? wxString("DarkModeDefault")
+            : _default;
 
-    wxString fileName = config().get(_PRYMARY, _default);
+    wxString fileName = config().get(_PRYMARY, systemDefault);
     if (fileName.IsEmpty()) {
-        fileName =_default;
+        fileName = systemDefault;
     }
     wxFileName file = wxFileName(config().getXmlStylesPath(), fileName + ".xml");
     setFileNamePrimary(file);
 
-    fileName = config().get(_SECONDARY, _default);
+    fileName = config().get(_SECONDARY, systemDefault);
     if (fileName.IsEmpty()) {
-        fileName = _default;
+        fileName = systemDefault;
     }
     file = wxFileName(config().getXmlStylesPath(), fileName + ".xml");
     setFileNameSecondary(file);

--- a/src/gui/HtmlTemplateProcessor.cpp
+++ b/src/gui/HtmlTemplateProcessor.cpp
@@ -138,18 +138,25 @@ void HtmlTemplateProcessor::applyDarkModeIfNeeded(wxString& html)
     // text color via the first <body...> tag so all unstyled text inherits
     // a light foreground. font color="white" cells (header rows) keep
     // their explicit color since attribute beats inheritance.
-    int bodyStart = html.Find("<body");
-    if (bodyStart != wxNOT_FOUND)
+    //
+    // Gemini-flagged: search case-insensitively (HTML is case-insensitive
+    // and templates outside this repo may use <BODY>) and use a single
+    // wxString::size_type for both ends so the slice math doesn't mix
+    // signed int with unsigned indices (the previous version returned
+    // int from html.Find but size_t from html.find).
+    wxString lower = html.Lower();
+    wxString::size_type bodyStart = lower.find(wxT("<body"));
+    if (bodyStart != wxString::npos)
     {
-        int bodyEnd = html.find('>', bodyStart);
-        if (bodyEnd != wxNOT_FOUND)
+        wxString::size_type bodyEnd = html.find('>', bodyStart);
+        if (bodyEnd != wxString::npos)
         {
-            // If the existing <body> already specifies text=, leave it
+            // If the existing <body...> already specifies text=, leave it
             // alone; otherwise insert text="#e0e0e0" before the closing >.
             wxString bodyTag = html.Mid(bodyStart, bodyEnd - bodyStart + 1);
-            if (bodyTag.Lower().Find("text=") == wxNOT_FOUND)
+            if (bodyTag.Lower().Find(wxT("text=")) == wxNOT_FOUND)
             {
-                html.insert(bodyEnd, " text=\"#e0e0e0\"");
+                html.insert(bodyEnd, wxT(" text=\"#e0e0e0\""));
             }
         }
     }

--- a/src/gui/HtmlTemplateProcessor.cpp
+++ b/src/gui/HtmlTemplateProcessor.cpp
@@ -30,6 +30,8 @@
     #include "wx/wx.h"
 #endif
 
+#include <wx/settings.h>
+
 #include "core/StringUtils.h"
 #include "frutils.h"
 #include "gui/HtmlHeaderMetadataItemVisitor.h"
@@ -97,5 +99,59 @@ void HtmlTemplateProcessor::processCommand(const wxString& cmdName,
 wxString HtmlTemplateProcessor::escapeChars(const wxString& input, bool processNewlines)
 {
     return escapeHtmlChars(input, processNewlines);
+}
+
+/*static*/
+void HtmlTemplateProcessor::applyDarkModeIfNeeded(wxString& html)
+{
+    // wxSystemAppearance::IsDark is the right check on every platform that
+    // exposes a dark mode (macOS Mojave+, Win10+, GTK with dark theme).
+    if (!wxSystemSettings::GetAppearance().IsDark())
+        return;
+
+    // Replace the legacy hard-coded bgcolor= attributes from the metadata
+    // templates with darker equivalents. We only touch the literal
+    // bgcolor="…" forms the templates emit, so user-provided values in
+    // descriptions or other content are unaffected.
+    struct ColorMap { const wxChar* from; const wxChar* to; };
+    static const ColorMap mapping[] = {
+        { wxT("bgcolor=\"white\""),   wxT("bgcolor=\"#1e1e1e\"") }, // outer wrapper
+        { wxT("bgcolor=\"black\""),   wxT("bgcolor=\"#3a3a3a\"") }, // table border
+        { wxT("bgcolor=\"silver\""),  wxT("bgcolor=\"#3a3a3a\"") }, // = #C0C0C0
+        { wxT("bgcolor=\"#999999\""), wxT("bgcolor=\"#3a3a3a\"") }, // dark legend border
+        { wxT("bgcolor=\"#CCCCCC\""), wxT("bgcolor=\"#2c2c2c\"") }, // legend row
+        { wxT("bgcolor=\"#DDDDDD\""), wxT("bgcolor=\"#34343c\"") }, // legend alt row
+        { wxT("bgcolor=\"#DDDDFF\""), wxT("bgcolor=\"#2c2c40\"") }, // metadata odd row
+        { wxT("bgcolor=\"#CCCCFF\""), wxT("bgcolor=\"#23233a\"") }, // metadata value cell
+    };
+    for (const ColorMap& m : mapping)
+        html.Replace(m.from, m.to);
+
+    // Some templates emit <font color="black"> for cells that sit on the
+    // grey backgrounds — that becomes black-on-dark after we recolor the
+    // backgrounds. Lift those explicit blacks to a light shade.
+    html.Replace(wxT("<font color=\"black\">"), wxT("<font color=\"#e0e0e0\">"));
+    html.Replace(wxT("<font color=black>"),     wxT("<font color=\"#e0e0e0\">"));
+
+    // Default text color in legacy wxHtmlWindow is black, which is
+    // unreadable on the dark backgrounds we just inserted. Inject a body
+    // text color via the first <body...> tag so all unstyled text inherits
+    // a light foreground. font color="white" cells (header rows) keep
+    // their explicit color since attribute beats inheritance.
+    int bodyStart = html.Find("<body");
+    if (bodyStart != wxNOT_FOUND)
+    {
+        int bodyEnd = html.find('>', bodyStart);
+        if (bodyEnd != wxNOT_FOUND)
+        {
+            // If the existing <body> already specifies text=, leave it
+            // alone; otherwise insert text="#e0e0e0" before the closing >.
+            wxString bodyTag = html.Mid(bodyStart, bodyEnd - bodyStart + 1);
+            if (bodyTag.Lower().Find("text=") == wxNOT_FOUND)
+            {
+                html.insert(bodyEnd, " text=\"#e0e0e0\"");
+            }
+        }
+    }
 }
 

--- a/src/gui/HtmlTemplateProcessor.cpp
+++ b/src/gui/HtmlTemplateProcessor.cpp
@@ -140,15 +140,16 @@ void HtmlTemplateProcessor::applyDarkModeIfNeeded(wxString& html)
     // their explicit color since attribute beats inheritance.
     //
     // HTML attribute names are case-insensitive, and external templates
-    // (the user manual, license viewer) may use mixed casing. Use the
-    // wxString::Find overload that takes a case-sensitivity flag — that
-    // searches in place rather than copying the document, which matters
-    // for multi-MB files.
-    int rawBodyStart = html.Find(wxT("<body"), false /* caseSensitive */);
-    if (rawBodyStart != wxNOT_FOUND)
+    // (the user manual, license viewer) may use mixed casing. wx 3.3's
+    // wxString::Find(const wxString&) doesn't expose a case-insensitive
+    // flag, so search a bounded lower-cased prefix instead — <body> is
+    // virtually always within the first few KB of any HTML document and
+    // copying 8 KB is cheap even for multi-MB inputs.
+    const size_t kBodySearchPrefix = 8 * 1024;
+    wxString lowerPrefix = html.Mid(0, kBodySearchPrefix).Lower();
+    wxString::size_type bodyStart = lowerPrefix.find(wxT("<body"));
+    if (bodyStart != wxString::npos)
     {
-        wxString::size_type bodyStart =
-            static_cast<wxString::size_type>(rawBodyStart);
         wxString::size_type bodyEnd = html.find('>', bodyStart);
         if (bodyEnd != wxString::npos)
         {

--- a/src/gui/HtmlTemplateProcessor.cpp
+++ b/src/gui/HtmlTemplateProcessor.cpp
@@ -139,22 +139,28 @@ void HtmlTemplateProcessor::applyDarkModeIfNeeded(wxString& html)
     // a light foreground. font color="white" cells (header rows) keep
     // their explicit color since attribute beats inheritance.
     //
-    // Gemini-flagged: search case-insensitively (HTML is case-insensitive
-    // and templates outside this repo may use <BODY>) and use a single
-    // wxString::size_type for both ends so the slice math doesn't mix
-    // signed int with unsigned indices (the previous version returned
-    // int from html.Find but size_t from html.find).
-    wxString lower = html.Lower();
-    wxString::size_type bodyStart = lower.find(wxT("<body"));
-    if (bodyStart != wxString::npos)
+    // HTML attribute names are case-insensitive, and external templates
+    // (the user manual, license viewer) may use mixed casing. Use the
+    // wxString::Find overload that takes a case-sensitivity flag — that
+    // searches in place rather than copying the document, which matters
+    // for multi-MB files.
+    int rawBodyStart = html.Find(wxT("<body"), false /* caseSensitive */);
+    if (rawBodyStart != wxNOT_FOUND)
     {
+        wxString::size_type bodyStart =
+            static_cast<wxString::size_type>(rawBodyStart);
         wxString::size_type bodyEnd = html.find('>', bodyStart);
         if (bodyEnd != wxString::npos)
         {
-            // If the existing <body...> already specifies text=, leave it
-            // alone; otherwise insert text="#e0e0e0" before the closing >.
+            // Look for an existing text= attribute, but require a
+            // leading separator (' ', '\t' or '\n') so we don't false-
+            // positive on attribute values that contain "text=" as a
+            // substring (e.g. <body class="main-text-area">).
             wxString bodyTag = html.Mid(bodyStart, bodyEnd - bodyStart + 1);
-            if (bodyTag.Lower().Find(wxT("text=")) == wxNOT_FOUND)
+            wxString lowerTag = bodyTag.Lower();
+            if (lowerTag.Find(wxT(" text=")) == wxNOT_FOUND
+                && lowerTag.Find(wxT("\ttext=")) == wxNOT_FOUND
+                && lowerTag.Find(wxT("\ntext=")) == wxNOT_FOUND)
             {
                 html.insert(bodyEnd, wxT(" text=\"#e0e0e0\""));
             }

--- a/src/gui/HtmlTemplateProcessor.h
+++ b/src/gui/HtmlTemplateProcessor.h
@@ -38,6 +38,13 @@ public:
     HtmlTemplateProcessor(ProcessableObject* object, wxWindow* window);
     virtual wxString escapeChars(const wxString& input,
         bool processNewlines = true);
+
+    // If the system appearance is dark, rewrite the rendered HTML to use
+    // dark-mode colors. The metadata templates use legacy bgcolor="white"
+    // / "#DDDDFF" / "#CCCCFF" attributes which clash with a dark window
+    // chrome; this is a post-processing pass so the templates themselves
+    // stay portable.
+    static void applyDarkModeIfNeeded(wxString& html);
 };
 
 #endif // FR_HTMLTEMPLATEPROCESSOR_H

--- a/src/gui/MetadataItemPropertiesFrame.cpp
+++ b/src/gui/MetadataItemPropertiesFrame.cpp
@@ -203,6 +203,7 @@ void MetadataItemPropertiesPanel::loadPage()
     wxString htmlpage;
     HtmlTemplateProcessor tp(objectM, this);
     tp.processTemplateFile(htmlpage, fileName, 0, &pd);
+    HtmlTemplateProcessor::applyDarkModeIfNeeded(htmlpage);
 
     pd.SetTitle(_("Rendering page..."));
 

--- a/src/gui/SimpleHtmlFrame.cpp
+++ b/src/gui/SimpleHtmlFrame.cpp
@@ -34,6 +34,7 @@
 #include "core/ArtProvider.h"
 #include "core/StringUtils.h"
 #include "gui/controls/PrintableHtmlWindow.h"
+#include "gui/HtmlTemplateProcessor.h"
 #include "gui/SimpleHtmlFrame.h"
 
 bool showHtmlFile(wxWindow* parent, const wxFileName& fileName)
@@ -68,7 +69,9 @@ SimpleHtmlFrame::SimpleHtmlFrame(wxWindow* parent, const wxFileName& fileName)
 
     // we don't use LoadPage here since we need PrintableHtmlWindow to
     // store a copy of HTML source for printing and SaveAsFile actions
-    html_window->setPageSource(loadEntireFile(fileName));
+    wxString htmlSource = loadEntireFile(fileName);
+    HtmlTemplateProcessor::applyDarkModeIfNeeded(htmlSource);
+    html_window->setPageSource(htmlSource);
 
     fileNameM = fileName.GetFullName();
     setIdString(this, getFrameId(fileName));

--- a/xml-styles/DarkModeDefault.xml
+++ b/xml-styles/DarkModeDefault.xml
@@ -58,7 +58,7 @@ License:             GPL2
         <WidgetStyle name="Fold" styleID="0" fgColor="707070" bgColor="101010"/>
         <WidgetStyle name="Fold active" styleID="0" fgColor="7F9F7F"/>
         <WidgetStyle name="Fold margin" styleID="0" fgColor="181818" bgColor="101010"/>
-        <WidgetStyle name="White space symbol" styleID="0" fgColor="5F5F5F"/>
+        <WidgetStyle name="White space symbol" styleID="0" fgColor="5F5F5F" bgColor="3F3F3F"/>
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="358A35"/>
         <WidgetStyle name="Find Mark Style" styleID="31" bgColor="FF0080"/>
         <WidgetStyle name="Mark Style 1" styleID="25" bgColor="88B090"/>


### PR DESCRIPTION
## Summary
Metadata properties pages and the simple HTML viewer use legacy templates with hard-coded \`bgcolor\` attributes (\`white\` outer wrapper, \`#DDDDFF\` / \`#CCCCFF\` metadata rows, \`#CCCCCC\` / \`#DDDDDD\` legend rows, etc.). Under a dark window chrome those panels render as bright white boxes that clash with everything around them, and the legend rows become unreadable when the surrounding \`wxHtmlWindow\` defaults text to black on the now-darker backgrounds.

Add \`HtmlTemplateProcessor::applyDarkModeIfNeeded()\` — a post-processing pass that runs only when \`wxSystemSettings::GetAppearance().IsDark()\` is true. It rewrites the eight literal \`bgcolor=\` forms the templates emit to dark equivalents, lifts explicit \`<font color="black">\` tags to a light shade, and injects \`text="#e0e0e0"\` into the \`<body>\` tag so default text inherits a light foreground. Templates themselves stay portable — light-mode users see exactly the same output as before.

Wired into the two HTML rendering entry points:
- \`MetadataItemPropertiesPanel\` (object properties / browse data)
- \`SimpleHtmlFrame\` (manual, what's new, license viewer)

## Test plan
- [ ] On a Mac in light mode, every metadata view renders identically to before
- [ ] On the same Mac switched to dark mode, all metadata pages render with dark backgrounds and light text — no white panels, no unreadable rows
- [ ] Same applies to Help → Manual / What's New / License viewer
- [ ] Switching system appearance during a session takes effect when the page is next loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)