### PR TITLE
Fix issue #546: correct ODS version check for RDB$CONDITION_SOURCE

### DIFF
--- a/docs/fr_whatsnew.html
+++ b/docs/fr_whatsnew.html
@@ -21,9 +21,9 @@ so recreated schemas lost WHERE conditions.<br>
 This change adds Firebird 5-aware metadata loading and emits partial-index predicates
 in extracted CREATE INDEX statements.<br>
 <br>
-<b>Metadata loading (Firebird 5 / ODS 13+)</b><br>
+<b>Metadata loading (Firebird 5 / ODS 13.1+)</b><br>
 - Extend index metadata queries to read RDB$INDICES.RDB$CONDITION_SOURCE<br>
-- Gate the column by ODS version (&gt;= 13.0) and fall back to NULL on older servers to keep compatibility<br>
+- Gate the column by ODS version (&gt;= 13.1) and fall back to NULL on older servers to keep compatibility<br>
 - Store condition text in Index (conditionM) with accessor support<br>
 <br>
 <b>DDL generation</b><br>

--- a/src/metadata/Index.cpp
+++ b/src/metadata/Index.cpp
@@ -56,7 +56,7 @@ void Index::loadProperties()
         " i.rdb$index_type, i.rdb$statistics, "
         " s.rdb$field_name, rc.rdb$constraint_name, i.rdb$expression_source, "
     );
-    sql += db->getInfo().getODSVersionIsHigherOrEqualTo(13, 0) ? " i.rdb$condition_source " : " null ";
+    sql += db->getInfo().getODSVersionIsHigherOrEqualTo(13, 1) ? " i.rdb$condition_source " : " null ";
     sql +=
         " from rdb$indices i "
         " left join rdb$index_segments s on i.rdb$index_name = s.rdb$index_name "

--- a/src/metadata/table.cpp
+++ b/src/metadata/table.cpp
@@ -389,7 +389,7 @@ void Table::loadIndices()
         " i.rdb$index_type, i.rdb$statistics, "
         " s.rdb$field_name, rc.rdb$constraint_name, i.rdb$expression_source, "
     );
-    sql += db->getInfo().getODSVersionIsHigherOrEqualTo(13, 0) ? " i.rdb$condition_source " : " null ";
+    sql += db->getInfo().getODSVersionIsHigherOrEqualTo(13, 1) ? " i.rdb$condition_source " : " null ";
     sql +=
         " from rdb$indices i "
         " left join rdb$index_segments s on i.rdb$index_name = s.rdb$index_name "


### PR DESCRIPTION
RDB$CONDITION_SOURCE was introduced in Firebird 5.0 (ODS 13.1) for partial indices. Checking for ODS >= 13.0 (Firebird 4.0) caused queries to fail when connecting to Firebird 4.0 databases. This PR updates the check to ODS 13.1.