### PR TITLE
database config - encrypt password by default (#549)

### DIFF
--- a/src/gui/DatabaseRegistrationDialog.cpp
+++ b/src/gui/DatabaseRegistrationDialog.cpp
@@ -336,7 +336,7 @@ void DatabaseRegistrationDialog::setControlsProperties()
     int wh = text_ctrl_dbpath->GetMinHeight();
     button_browse->SetSize(wh, wh);
 
-    choice_authentication->SetSelection(1);
+    choice_authentication->SetSelection(DatabaseAuthenticationMode::UseSavedEncryptedPwd);
     combobox_charset->SetStringSelection("NONE");
     if (createM)
     {

--- a/src/gui/DatabaseRegistrationDialog.cpp
+++ b/src/gui/DatabaseRegistrationDialog.cpp
@@ -336,7 +336,7 @@ void DatabaseRegistrationDialog::setControlsProperties()
     int wh = text_ctrl_dbpath->GetMinHeight();
     button_browse->SetSize(wh, wh);
 
-    choice_authentication->SetSelection(0);
+    choice_authentication->SetSelection(1);
     combobox_charset->SetStringSelection("NONE");
     if (createM)
     {

--- a/src/metadata/database.cpp
+++ b/src/metadata/database.cpp
@@ -226,7 +226,7 @@ void DatabaseInfo::reloadIfNecessary(const IBPP::Database database)
 
 // DatabaseAuthenticationMode class
 DatabaseAuthenticationMode::DatabaseAuthenticationMode()
-    : modeM(UseSavedPassword)
+    : modeM(UseSavedEncryptedPwd)
 {
 }
 


### PR DESCRIPTION
This PR addresses issue #549 by making encrypted passwords the default choice when registering or creating a database.

Changes:
- Set `DatabaseAuthenticationMode` default to `UseSavedEncryptedPwd`.
- Updated `DatabaseRegistrationDialog` to default to the "Use saved user name and encrypted password" option (index 1).

This ensures that if a user chooses to save their password, it will be encrypted by default using the Master Password feature, rather than being stored in plain text in the `fr_databases.conf` file.