### PR TITLE
style configurator - fix orange theme bug and dark mode default (#550)

### DIFF
--- a/conf-defs/fr_settings.confdef
+++ b/conf-defs/fr_settings.confdef
@@ -432,7 +432,7 @@
 				<caption>	</caption>
                 <description>Select the file with the primary style</description>
                 <key>StyleTheme</key>
-				<default>styles</default>
+				<default>stylers</default>
 				<aligngroup>1</aligngroup>
                 <file>StyleTheme</file>
             </setting>

--- a/src/gui/FRStyleManager.cpp
+++ b/src/gui/FRStyleManager.cpp
@@ -37,6 +37,7 @@
 
 #include "FRStyleManager.h"
 
+const wxString FRStyleManager::_DARKMODEDEFAULT = "DarkModeDefault";
 
 FRStyleManager& stylerManager()
 {
@@ -349,7 +350,7 @@ void FRStyleManager::loadConfig()
     // user's explicit Preferences choice still wins.
     const wxString systemDefault =
         wxSystemSettings::GetAppearance().IsDark()
-            ? wxString("DarkModeDefault")
+            ? _DARKMODEDEFAULT
             : _default;
 
     wxString fileName = config().get(_PRYMARY, systemDefault);

--- a/src/gui/FRStyleManager.h
+++ b/src/gui/FRStyleManager.h
@@ -36,6 +36,8 @@ private:
     const wxString _SECONDARY = "StyleThemeSecondary";
     const wxString _STYLEACTIVE = "StyleActive";
     const wxString _default = "stylers";
+public:
+    static const wxString _DARKMODEDEFAULT;
 
     wxFileName fileNamePrimaryM;
     wxFileName fileNameSecondaryM;

--- a/src/gui/PreferencesDialogStyle.cpp
+++ b/src/gui/PreferencesDialogStyle.cpp
@@ -221,10 +221,8 @@ bool PrefDlgStyleSetting::loadFromTargetConfig(Config& config)
     {
         wxString value = defaultM;
         // If system is dark and no value in config, use DarkModeDefault
-        if (wxSystemSettings::GetAppearance().IsDark() && !config.keyExists(keyM))
-            value = "DarkModeDefault";
-        else
-            config.getValue(keyM, value);
+        if (!config.getValue(keyM, value) && wxSystemSettings::GetAppearance().IsDark())
+            value = FRStyleManager::_DARKMODEDEFAULT;
 
         fileComboBoxM->SetValue(value);
 
@@ -234,10 +232,8 @@ bool PrefDlgStyleSetting::loadFromTargetConfig(Config& config)
     if (fileSecondaryComboBoxM)
     {
         wxString value = defaultM;
-        if (wxSystemSettings::GetAppearance().IsDark() && !config.keyExists("StyleThemeSecondary"))
-            value = "DarkModeDefault";
-        else
-            config.getValue("StyleThemeSecondary", value);
+        if (!config.getValue("StyleThemeSecondary", value) && wxSystemSettings::GetAppearance().IsDark())
+            value = FRStyleManager::_DARKMODEDEFAULT;
         fileSecondaryComboBoxM->SetValue(value);
     }
 

--- a/src/gui/PreferencesDialogStyle.cpp
+++ b/src/gui/PreferencesDialogStyle.cpp
@@ -220,7 +220,12 @@ bool PrefDlgStyleSetting::loadFromTargetConfig(Config& config)
     if (fileComboBoxM)
     {
         wxString value = defaultM;
-        config.getValue(keyM, value);
+        // If system is dark and no value in config, use DarkModeDefault
+        if (wxSystemSettings::GetAppearance().IsDark() && !config.keyExists(keyM))
+            value = "DarkModeDefault";
+        else
+            config.getValue(keyM, value);
+
         fileComboBoxM->SetValue(value);
 
         loadStylers(fileComboBoxM->GetValue());
@@ -229,7 +234,10 @@ bool PrefDlgStyleSetting::loadFromTargetConfig(Config& config)
     if (fileSecondaryComboBoxM)
     {
         wxString value = defaultM;
-        config.getValue("StyleThemeSecondary", value);
+        if (wxSystemSettings::GetAppearance().IsDark() && !config.keyExists("StyleThemeSecondary"))
+            value = "DarkModeDefault";
+        else
+            config.getValue("StyleThemeSecondary", value);
         fileSecondaryComboBoxM->SetValue(value);
     }
 

--- a/xml-styles/stylers.xml
+++ b/xml-styles/stylers.xml
@@ -33,7 +33,7 @@
     </LexerStyles>
     <GlobalStyles>
         <!-- Attention : Don't modify the name of styleID="0" -->
-        <WidgetStyle name="Global override" styleID="0" fgColor="FFFF80" bgColor="FF8000" fontName="Courier New" fontStyle="0" fontSize="10" caseVisible="0"/>
+        <WidgetStyle name="Global override" styleID="0" fgColor="000000" bgColor="FFFFFF" fontName="Courier New" fontStyle="0" fontSize="10" caseVisible="0"/>
         <WidgetStyle name="Default Style" styleID="32" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" caseVisible="0"/>
         <WidgetStyle name="Indent guideline style" styleID="37" fgColor="C0C0C0" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" caseVisible="0"/>
         <WidgetStyle name="Brace highlight style" styleID="34" fgColor="FF0000" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" caseVisible="0"/>


### PR DESCRIPTION
This PR fixes issue #550 where the style configurator would apply an orange theme incorrectly.

### Changes:
- **`xml-styles/stylers.xml`**: Changed the "Global override" background from orange (`FF8000`) to white and the foreground to black. This prevents the "orange surprise" when falling back to the default theme.
- **`conf-defs/fr_settings.confdef`**: Corrected the default style theme name from `styles` to `stylers` to match the actual file name and the internal `_default` constant.
- **`src/gui/PreferencesDialogStyle.cpp`**: Added logic to `loadFromTargetConfig` to use `DarkModeDefault` when the system is in dark mode and no explicit theme has been saved yet. This ensures the Preferences dialog matches the application's initial dark state instead of reverting to the light default theme.

These changes ensure a consistent experience across Dark and Light modes and fix the jarring orange color issue reported.