### PR TITLE
Phase 2: Metadata & Core Refactoring - Step 1: DAL Migration

### DIFF
--- a/src/engine/MetadataLoader.cpp
+++ b/src/engine/MetadataLoader.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2004-2022 The FlameRobin Development Team
+  Copyright (c) 2004-2026 The FlameRobin Development Team
 
   Permission is hereby granted, free of charge, to any person obtaining
   a copy of this software and associated documentation files (the
@@ -34,7 +34,7 @@
 #include "metadata/database.h"
 
 MetadataLoader::MetadataLoader(Database& database, unsigned maxStatements)
-    : databaseM(database.getIBPPDatabase()), transactionM(),
+    : databaseM(database.getDALDatabase()), transactionM(),
         transactionLevelM(0), statementsM(), maxStatementsM(maxStatements)
 {
 }
@@ -43,67 +43,68 @@ void MetadataLoader::transactionStart()
 {
     ++transactionLevelM;
 
-    // fix the IBPP::LogicException "No Database is attached."
-    // which happens after a database reconnect
-    // (this action detaches the database from all its transactions)
-    if (transactionM != 0 && !transactionM->Started())
+    if (transactionM != nullptr && !transactionM->isActive())
     {
         try
         {
-            transactionM->Start();
+            transactionM->start();
         }
-        catch (IBPP::LogicException&)
+        catch (...)
         {
-            transactionM = 0;
+            transactionM = nullptr;
         }
     }
 
-    if (transactionM == 0)
-        transactionM = IBPP::TransactionFactory(databaseM, IBPP::amRead);
-    if (!transactionM->Started())
-        transactionM->Start();
+    if (transactionM == nullptr)
+    {
+        transactionM = databaseM->createTransaction();
+        transactionM->setAccessMode(fr::TransactionAccessMode::Read);
+    }
+    if (!transactionM->isActive())
+        transactionM->start();
 }
 
 void MetadataLoader::transactionCommit()
 {
-    if (--transactionLevelM == 0 && transactionM != 0)
+    if (--transactionLevelM == 0 && transactionM != nullptr)
     {
         statementsM.clear();
-        transactionM->Commit();
-        transactionM = 0;
+        transactionM->commit();
+        transactionM = nullptr;
     }
 }
 
 bool MetadataLoader::transactionStarted()
 {
-    return (transactionM != 0 && transactionM->Started());
+    return (transactionM != nullptr && transactionM->isActive());
 }
 
-IBPP::Statement MetadataLoader::createStatement(const std::string& sql)
+fr::IStatementPtr MetadataLoader::createStatement(const std::string& sql)
 {
     wxASSERT(transactionStarted());
-
-    return IBPP::StatementFactory(databaseM, transactionM, sql);
+    fr::IStatementPtr stmt = databaseM->createStatement(transactionM);
+    stmt->prepare(sql);
+    return stmt;
 }
 
-MetadataLoader::IBPPStatementListIterator MetadataLoader::findStatement(
+MetadataLoader::StatementListIterator MetadataLoader::findStatement(
     const std::string& sql)
 {
-    for (IBPPStatementListIterator it = statementsM.begin();
+    for (StatementListIterator it = statementsM.begin();
         it != statementsM.end(); ++it)
     {
-        if ((*it)->Sql() == sql)
+        if ((*it)->getSql() == sql)
             return it;
     }
     return statementsM.end();
 }
 
-IBPP::Statement& MetadataLoader::getStatement(const std::string& sql)
+fr::IStatementPtr& MetadataLoader::getStatement(const std::string& sql)
 {
     wxASSERT(transactionStarted());
 
-    IBPP::Statement stmt;
-    IBPPStatementListIterator it = findStatement(sql);
+    fr::IStatementPtr stmt;
+    StatementListIterator it = findStatement(sql);
     if (it != statementsM.end())
     {
         stmt = (*it);
@@ -111,7 +112,8 @@ IBPP::Statement& MetadataLoader::getStatement(const std::string& sql)
     }
     else
     {
-        stmt = IBPP::StatementFactory(databaseM, transactionM, sql);
+        stmt = databaseM->createStatement(transactionM);
+        stmt->prepare(sql);
     }
     statementsM.push_front(stmt);
     limitListSize();
@@ -123,16 +125,16 @@ void MetadataLoader::limitListSize()
     if (maxStatementsM)
     {
         while (statementsM.size() > maxStatementsM)
-            statementsM.remove(statementsM.back());
+            statementsM.pop_back();
     }
 }
 
 void MetadataLoader::releaseStatements()
 {
     statementsM.clear();
-    if (transactionM != 0 && transactionM->Started())
+    if (transactionM != nullptr && transactionM->isActive())
     {
-        transactionM->Commit();
+        transactionM->commit();
         transactionLevelM = 0;
     }
 }
@@ -144,13 +146,6 @@ void MetadataLoader::setMaximumConcurrentStatements(unsigned count)
         maxStatementsM = count;
         limitListSize();
     }
-}
-
-IBPP::Blob MetadataLoader::createBlob()
-{
-    wxASSERT(transactionStarted());
-
-    return IBPP::BlobFactory(databaseM, transactionM);
 }
 
 MetadataLoaderTransaction::MetadataLoaderTransaction(MetadataLoader* loader)
@@ -165,4 +160,3 @@ MetadataLoaderTransaction::~MetadataLoaderTransaction()
     if (loaderM)
         loaderM->transactionCommit();
 }
-

--- a/src/engine/MetadataLoader.h
+++ b/src/engine/MetadataLoader.h
@@ -27,7 +27,9 @@
 #include <list>
 #include <string>
 
-#include <ibpp.h>
+#include "engine/db/IDatabase.h"
+#include "engine/db/ITransaction.h"
+#include "engine/db/IStatement.h"
 
 class Database;
 class MetadataLoaderTransaction;
@@ -35,20 +37,20 @@ class MetadataLoaderTransaction;
 class MetadataLoader
 {
 private:
-    typedef std::list<IBPP::Statement> IBPPStatementList;
-    typedef std::list<IBPP::Statement>::iterator IBPPStatementListIterator;
+    typedef std::list<fr::IStatementPtr> StatementList;
+    typedef std::list<fr::IStatementPtr>::iterator StatementListIterator;
 
     friend class MetadataLoaderTransaction;
 
-    IBPP::Database databaseM;
-    IBPP::Transaction transactionM;
+    fr::IDatabasePtr databaseM;
+    fr::ITransactionPtr transactionM;
     unsigned transactionLevelM;
 
-    std::list<IBPP::Statement> statementsM;
+    std::list<fr::IStatementPtr> statementsM;
     unsigned maxStatementsM;
-    // Returns an iterator to the prepared IBPP::Statement object
+    // Returns an iterator to the prepared fr::IStatementPtr object
     // for the sql statement if available, else returns statementsM.end().
-    IBPPStatementListIterator findStatement(const std::string& sql);
+    StatementListIterator findStatement(const std::string& sql);
     // Releases any assigned statement objects beyond the list size limit.
     void limitListSize();
 
@@ -66,34 +68,32 @@ private:
 
 public:
     // Creates MetadataLoader object for the database, which will use
-    // a maximum of maxStatements assigned IBPP::Statement objects to
+    // a maximum of maxStatements assigned fr::IStatementPtr objects to
     // improve load times of metadata items.
     // Setting the parameter maxStatements to 0 will disable the size limit
     // of the statementsM list, and could possibly consume a lot of the
     // available server ressources!
     MetadataLoader(Database& database, unsigned maxStatements = 1);
 
-    // Creates a prepared IBPP::Statement object for the sql statement.
+    // Creates a prepared fr::IStatementPtr object for the sql statement.
     // Should be used in cases where sql is unique and can not be reused,
     // but should still use the same transaction.  This way the cached
     // statements will not be replaced.
-    IBPP::Statement createStatement(const std::string& sql);
-    // returns a reference to a prepared IBPP::Statement object for the
+    fr::IStatementPtr createStatement(const std::string& sql);
+    // returns a reference to a prepared fr::IStatementPtr object for the
     // sql statement, either recycled, newly created, or newly prepared
-    // using the least recently used IBPP::Statement in statementsM
-    IBPP::Statement& getStatement(const std::string& sql);
-    // releases any assigned IBPP::Statement objects while keeping the maximum
+    // using the least recently used fr::IStatementPtr in statementsM
+    fr::IStatementPtr& getStatement(const std::string& sql);
+    // releases any assigned fr::IStatementPtr objects while keeping the maximum
     // number of objects untouched
     void releaseStatements();
-    // readjusts maximum number of IBPP::Statement objects in statementsM,
+    // readjusts maximum number of fr::IStatementPtr objects in statementsM,
     // releasing any assigned statement objects beyond the new limit
     // setting the parameter count to 0 will disable the size limit of the
     // statementsM list, and could possibly consume a lot of the available
     // server ressources!
     void setMaximumConcurrentStatements(unsigned count);
 
-    // Creates an IBPP::Blob object using the database and transaction
-    IBPP::Blob createBlob();
 };
 
 class MetadataLoaderTransaction

--- a/src/engine/db/IDatabase.h
+++ b/src/engine/db/IDatabase.h
@@ -42,6 +42,8 @@ public:
     virtual void setCredentials(const std::string& user, const std::string& password) = 0;
     virtual void setRole(const std::string& role) = 0;
     virtual void setCharset(const std::string& charset) = 0;
+    virtual void setClientLibrary(const std::string& clientLib) = 0;
+    virtual void setCryptKeyData(const std::string& cryptKeyData) = 0;
 
     virtual ITransactionPtr createTransaction() = 0;
     virtual IStatementPtr createStatement(ITransactionPtr tr) = 0;

--- a/src/engine/db/IStatement.h
+++ b/src/engine/db/IStatement.h
@@ -38,6 +38,7 @@ public:
     virtual ~IStatement() = default;
 
     virtual void prepare(const std::string& sql) = 0;
+    virtual std::string getSql() const = 0;
     virtual void execute() = 0;
     virtual bool fetch() = 0;
     virtual void close() = 0;

--- a/src/engine/db/fbcpp/FbCppDatabase.cpp
+++ b/src/engine/db/fbcpp/FbCppDatabase.cpp
@@ -88,6 +88,16 @@ void FbCppDatabase::setCharset(const std::string& charset)
     charsetM = charset;
 }
 
+void FbCppDatabase::setClientLibrary(const std::string& clientLib)
+{
+    clientLibM = clientLib;
+}
+
+void FbCppDatabase::setCryptKeyData(const std::string& cryptKeyData)
+{
+    cryptKeyDataM = cryptKeyData;
+}
+
 ITransactionPtr FbCppDatabase::createTransaction()
 {
     if (!attachmentM)

--- a/src/engine/db/fbcpp/FbCppDatabase.h
+++ b/src/engine/db/fbcpp/FbCppDatabase.h
@@ -46,6 +46,8 @@ public:
     virtual void setCredentials(const std::string& user, const std::string& password) override;
     virtual void setRole(const std::string& role) override;
     virtual void setCharset(const std::string& charset) override;
+    virtual void setClientLibrary(const std::string& clientLib) override;
+    virtual void setCryptKeyData(const std::string& cryptKeyData) override;
 
     virtual ITransactionPtr createTransaction() override;
     virtual IStatementPtr createStatement(ITransactionPtr tr) override;
@@ -67,6 +69,8 @@ private:
     std::string passwordM;
     std::string roleM;
     std::string charsetM;
+    std::string clientLibM;
+    std::string cryptKeyDataM;
 };
 
 } // namespace fr

--- a/src/engine/db/fbcpp/FbCppStatement.cpp
+++ b/src/engine/db/fbcpp/FbCppStatement.cpp
@@ -34,7 +34,13 @@ FbCppStatement::FbCppStatement(fbcpp::Attachment& attachment, fbcpp::Transaction
 
 void FbCppStatement::prepare(const std::string& sql)
 {
+    sqlM = sql;
     statementM.emplace(attachmentM, transactionM, sql);
+}
+
+std::string FbCppStatement::getSql() const
+{
+    return sqlM;
 }
 
 void FbCppStatement::execute()

--- a/src/engine/db/fbcpp/FbCppStatement.h
+++ b/src/engine/db/fbcpp/FbCppStatement.h
@@ -38,6 +38,7 @@ public:
     virtual ~FbCppStatement() = default;
 
     virtual void prepare(const std::string& sql) override;
+    virtual std::string getSql() const override;
     virtual void execute() override;
     virtual bool fetch() override;
     virtual void close() override;
@@ -65,6 +66,7 @@ public:
 private:
     fbcpp::Attachment& attachmentM;
     fbcpp::Transaction& transactionM;
+    std::string sqlM;
     std::optional<fbcpp::Statement> statementM;
     std::optional<fbcpp::RowSet> rowSetM;
 };

--- a/src/engine/db/ibpp/IbppDatabase.cpp
+++ b/src/engine/db/ibpp/IbppDatabase.cpp
@@ -35,7 +35,8 @@ IbppDatabase::IbppDatabase()
 
 void IbppDatabase::connect()
 {
-    databaseM = IBPP::DatabaseFactory("", connStrM, userM, passwordM, roleM, charsetM, "");
+    databaseM = IBPP::DatabaseFactory("", connStrM, userM, passwordM, roleM,
+        charsetM, "", clientLibM, cryptKeyDataM);
     databaseM->Connect();
 }
 
@@ -69,6 +70,16 @@ void IbppDatabase::setRole(const std::string& role)
 void IbppDatabase::setCharset(const std::string& charset)
 {
     charsetM = charset;
+}
+
+void IbppDatabase::setClientLibrary(const std::string& clientLib)
+{
+    clientLibM = clientLib;
+}
+
+void IbppDatabase::setCryptKeyData(const std::string& cryptKeyData)
+{
+    cryptKeyDataM = cryptKeyData;
 }
 
 ITransactionPtr IbppDatabase::createTransaction()

--- a/src/engine/db/ibpp/IbppDatabase.h
+++ b/src/engine/db/ibpp/IbppDatabase.h
@@ -44,6 +44,8 @@ public:
     virtual void setCredentials(const std::string& user, const std::string& password) override;
     virtual void setRole(const std::string& role) override;
     virtual void setCharset(const std::string& charset) override;
+    virtual void setClientLibrary(const std::string& clientLib) override;
+    virtual void setCryptKeyData(const std::string& cryptKeyData) override;
 
     virtual ITransactionPtr createTransaction() override;
     virtual IStatementPtr createStatement(ITransactionPtr tr) override;
@@ -59,6 +61,8 @@ private:
     std::string passwordM;
     std::string roleM;
     std::string charsetM;
+    std::string clientLibM;
+    std::string cryptKeyDataM;
 };
 
 } // namespace fr

--- a/src/engine/db/ibpp/IbppStatement.cpp
+++ b/src/engine/db/ibpp/IbppStatement.cpp
@@ -37,6 +37,11 @@ void IbppStatement::prepare(const std::string& sql)
     statementM->Prepare(sql);
 }
 
+std::string IbppStatement::getSql() const
+{
+    return statementM->Sql();
+}
+
 void IbppStatement::execute()
 {
     statementM->Execute();
@@ -89,6 +94,31 @@ bool IbppStatement::isNull(int index)
 
 std::string IbppStatement::getString(int index)
 {
+    if (getColumnType(index) == ColumnType::Blob)
+    {
+        IBPP::Blob b = IBPP::BlobFactory(statementM->DatabasePtr(), statementM->TransactionPtr());
+        statementM->Get(index + 1, b);
+        try
+        {
+            b->Open();
+        }
+        catch (...)
+        {
+            return "";
+        }
+        std::string result;
+        char buffer[8192];
+        while (true)
+        {
+            int size = b->Read(buffer, 8192 - 1);
+            if (size <= 0)
+                break;
+            buffer[size] = 0;
+            result += buffer;
+        }
+        b->Close();
+        return result;
+    }
     std::string value;
     statementM->Get(index + 1, value);
     return value;

--- a/src/engine/db/ibpp/IbppStatement.h
+++ b/src/engine/db/ibpp/IbppStatement.h
@@ -37,6 +37,7 @@ public:
     virtual ~IbppStatement() = default;
 
     virtual void prepare(const std::string& sql) override;
+    virtual std::string getSql() const override;
     virtual void execute() override;
     virtual bool fetch() override;
     virtual void close() override;

--- a/src/frutils.cpp
+++ b/src/frutils.cpp
@@ -64,37 +64,15 @@ void adjustControlsMinWidth(std::list<wxWindow*> controls)
     }
 }
 
-void readBlob(IBPP::Statement& st, int column, wxString& result,
+void readBlob(fr::IStatementPtr& st, int column, wxString& result,
     wxMBConv* conv)
 {
     result = "";
-    if (st->IsNull(column))
+    if (st->isNull(column))
         return;
 
-    IBPP::Blob b = IBPP::BlobFactory(st->DatabasePtr(), st->TransactionPtr());
-    st->Get(column, b);
-
-    try              // if blob is empty the exception is thrown
-    {                // I tried to check st1->IsNull(1) but it doesn't work
-        b->Open();   // to this hack is the only way (for the time being)
-    }
-    catch (...)
-    {
-        return;
-    }
-
-    std::string resultBuffer;
-    char readBuffer[8192];        // 8K block
-    while (true)
-    {
-        int size = b->Read(readBuffer, 8192-1);
-        if (size <= 0)
-            break;
-        readBuffer[size] = 0;
-        resultBuffer += readBuffer;
-    }
-    result = wxString(resultBuffer.c_str(), *conv);
-    b->Close();
+    std::string s = st->getString(column);
+    result = wxString(s.c_str(), *conv);
 }
 
 wxString selectRelationColumns(Relation* t, wxWindow* parent)

--- a/src/frutils.h
+++ b/src/frutils.h
@@ -31,6 +31,7 @@
 
 #include <ibpp.h>
 
+#include "engine/db/IStatement.h"
 #include "metadata/MetadataClasses.h"
 
 class ProgressDialog;
@@ -40,7 +41,7 @@ class ProgressIndicator;
 void adjustControlsMinWidth(std::list<wxWindow*> controls);
 
 //! reads blob from statement into wxString
-void readBlob(IBPP::Statement& st, int column, wxString& result,
+void readBlob(fr::IStatementPtr& st, int column, wxString& result,
     wxMBConv* conv);
 
 //! displays a list of table columns and lets user select some

--- a/src/gui/FieldPropertiesDialog.cpp
+++ b/src/gui/FieldPropertiesDialog.cpp
@@ -319,7 +319,7 @@ bool FieldPropertiesDialog::getNotNullConstraintName(const wxString& fieldName,
         MetadataLoader* loader = db->getMetadataLoader();
         MetadataLoaderTransaction tr(loader);
 
-        IBPP::Statement& st1 = loader->getStatement(
+        fr::IStatementPtr& st1 = loader->getStatement(
             "SELECT rc.RDB$CONSTRAINT_NAME FROM RDB$RELATION_CONSTRAINTS rc "
             "JOIN RDB$CHECK_CONSTRAINTS cc "
             "ON rc.RDB$CONSTRAINT_NAME = cc.RDB$CONSTRAINT_NAME "
@@ -327,13 +327,12 @@ bool FieldPropertiesDialog::getNotNullConstraintName(const wxString& fieldName,
             "AND rc.RDB$RELATION_NAME = ?"
             "AND cc.RDB$TRIGGER_NAME = ?");
 
-        st1->Set(1, wx2std(tableM->getName_(), conv));
-        st1->Set(2, wx2std(fieldName, conv));
-        st1->Execute();
-        if (st1->Fetch())
+        st1->setString(0, wx2std(tableM->getName_(), conv));
+        st1->setString(1, wx2std(fieldName, conv));
+        st1->execute();
+        if (st1->fetch())
         {
-            std::string s;
-            st1->Get(1, s);
+            std::string s = st1->getString(0);
             constraintName = std2wxIdentifier(s, conv);
             return true;
         }

--- a/src/metadata/CharacterSet.cpp
+++ b/src/metadata/CharacterSet.cpp
@@ -72,23 +72,23 @@ std::string CharacterSet::getLoadStatement(bool list)
     return stmt;
 }
 
-void CharacterSet::loadProperties(IBPP::Statement& statement, wxMBConv* converter)
+void CharacterSet::loadProperties(fr::IStatementPtr& statement, wxMBConv* converter)
 {
     setPropertiesLoaded(false);
 
     int Lid;
     std::string Lstr;
-    statement->Get(2, Lid);
+    Lid = statement->getInt32(1);
     setMetadataId(Lid);
-    statement->Get(3, Lid);
+    Lid = statement->getInt32(2);
     setBytesPerChar(Lid);
-    
-    statement->Get(4, Lstr);
+
+    Lstr = statement->getString(3);
     setCollationDefault(std2wxIdentifier(Lstr, converter));
 
-    if (!statement->IsNull(5))
+    if (!statement->isNull(4))
     {
-        statement->Get(5, Lstr);
+        Lstr = statement->getString(4);
         setOriginalCollationDefault(std2wxIdentifier(Lstr, converter));
     }
     else
@@ -96,7 +96,6 @@ void CharacterSet::loadProperties(IBPP::Statement& statement, wxMBConv* converte
 
     setPropertiesLoaded(true);
 }
-
 void CharacterSet::loadProperties()
 {
     setPropertiesLoaded(false);
@@ -106,10 +105,10 @@ void CharacterSet::loadProperties()
     MetadataLoaderTransaction tr(loader);
     wxMBConv* converter = db->getCharsetConverter();
 
-    IBPP::Statement& st1 = loader->getStatement(getLoadStatement(false));
-    st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
-    if (!st1->Fetch())
+    fr::IStatementPtr& st1 = loader->getStatement(getLoadStatement(false));
+    st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
+    if (!st1->fetch())
         throw FRError(_("Exception not found: ") + getName_());
 
     loadProperties(st1, converter);
@@ -135,25 +134,24 @@ void CharacterSet::loadChildren()
         "Order by c.RDB$CHARACTER_SET_NAME, k.RDB$COLLATION_ID "
     );
 
-    IBPP::Statement st1 = loader->getStatement(sql);
-    st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
+    fr::IStatementPtr& st1 = loader->getStatement(sql);
+    st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
 
     CollationPtrs collations;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        std::string s;
-        st1->Get(1, s);
+        std::string s = st1->getString(0);
         wxString name(std2wxIdentifier(s, converter));
-        
+
         CollationPtr coll = findCollation(name);
         if (!coll) {
-            coll.reset(new Collation(this, name));
+            coll.reset(new Collation(db, name));
             initializeLockCount(coll, getLockCount());
         }
         collations.push_back(coll);
-
-
+        coll->loadProperties(st1, converter);
+    }
     }
 
     setChildrenLoaded(true);
@@ -303,18 +301,17 @@ void CharacterSets::load(ProgressIndicator* progressIndicator)
     MetadataLoaderTransaction tr(loader);
     wxMBConv* converter = db->getCharsetConverter();
 
-    IBPP::Statement& st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         CharacterSet::getLoadStatement(true));
 
     CollectionType characters;
-    st1->Execute();
+    st1->execute();
     checkProgressIndicatorCanceled(progressIndicator);
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        if (!st1->IsNull(1))
+        if (!st1->isNull(0))
         {
-            std::string s;
-            st1->Get(1, s);
+            std::string s = st1->getString(0);
             wxString name(std2wxIdentifier(s, converter));
 
             CharacterSetPtr character = findByName(name);

--- a/src/metadata/CharacterSet.cpp
+++ b/src/metadata/CharacterSet.cpp
@@ -152,7 +152,6 @@ void CharacterSet::loadChildren()
         collations.push_back(coll);
         coll->loadProperties(st1, converter);
     }
-    }
 
     setChildrenLoaded(true);
 

--- a/src/metadata/CharacterSet.h
+++ b/src/metadata/CharacterSet.h
@@ -47,7 +47,7 @@ protected:
     CollationPtr findCollation(const wxString& name) const;
 
     static std::string getLoadStatement(bool list);
-    void loadProperties(IBPP::Statement& statement, wxMBConv* converter);
+    void loadProperties(fr::IStatementPtr& statement, wxMBConv* converter);
     virtual void loadProperties();
 
     virtual void loadChildren();

--- a/src/metadata/Collation.cpp
+++ b/src/metadata/Collation.cpp
@@ -58,29 +58,29 @@ std::string Collation::getLoadStatement(bool list)
     return stmt;
 }
 
-void Collation::loadProperties(IBPP::Statement& statement, wxMBConv* converter)
+void Collation::loadProperties(fr::IStatementPtr& statement, wxMBConv* converter)
 {
     setPropertiesLoaded(false);
 
     int Lid;
     std::string Lstr;
 
-    //statement->Get(1, Lstr);
+    //Lstr = statement->getString(0);
     //setName(std2wxIdentifier(Lstr, converter));
 
-    statement->Get(2, Lid);
+    Lid = statement->getInt32(1);
     setMetadataId(Lid);
 
-    statement->Get(3, Lid);
+    Lid = statement->getInt32(2);
     setAttributes(Lid);
 
-    statement->Get(4, Lstr);
+    Lstr = statement->getString(3);
     setBaseCollectionName(std2wxIdentifier(Lstr, converter));
 
-    statement->Get(5, Lstr);
+    Lstr = statement->getString(4);
     setSpecificAttributes(std2wxIdentifier(Lstr, converter));
 
-    statement->Get(6, Lid);
+    Lid = statement->getInt32(5);
     setCharacterSetId(Lid);
 
     setPropertiesLoaded(true);
@@ -95,10 +95,10 @@ void Collation::loadProperties()
     MetadataLoaderTransaction tr(loader);
     wxMBConv* converter = db->getCharsetConverter();
 
-    IBPP::Statement& st1 = loader->getStatement(getLoadStatement(false));
-    st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
-    if (!st1->Fetch())
+    fr::IStatementPtr& st1 = loader->getStatement(getLoadStatement(false));
+    st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
+    if (!st1->fetch())
         throw FRError(_("Exception not found: ") + getName_());
 
     loadProperties(st1, converter);

--- a/src/metadata/Collation.h
+++ b/src/metadata/Collation.h
@@ -46,16 +46,15 @@ private:
     wxString specificAttibutesM;
 
     friend class SysCollations;
-protected:
-    static std::string getLoadStatement(bool list);
-    void loadProperties(fr::IStatementPtr& statement, wxMBConv* converter);
-    virtual void loadProperties();
-
 public:
     Collation();
     Collation(DatabasePtr database, const wxString& name, int id = -1);
     Collation(MetadataItem* parent, const wxString& name, int id = -1);
     ~Collation();
+
+    static std::string getLoadStatement(bool list);
+    void loadProperties(fr::IStatementPtr& statement, wxMBConv* converter);
+    virtual void loadProperties();
 
     CharacterSet* getCharacterSet() const;
 

--- a/src/metadata/Collation.h
+++ b/src/metadata/Collation.h
@@ -48,7 +48,7 @@ private:
     friend class SysCollations;
 protected:
     static std::string getLoadStatement(bool list);
-    void loadProperties(IBPP::Statement& statement, wxMBConv* converter);
+    void loadProperties(fr::IStatementPtr& statement, wxMBConv* converter);
     virtual void loadProperties();
 
 public:

--- a/src/metadata/Index.cpp
+++ b/src/metadata/Index.cpp
@@ -65,43 +65,41 @@ void Index::loadProperties()
         " where i.rdb$index_name = ? "
         " order by i.rdb$index_name, s.rdb$field_position ";
 
-    IBPP::Statement& st1 = loader->getStatement(sql);
+    fr::IStatementPtr& st1 = loader->getStatement(sql);
 
-    st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
+    st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
     Index* i = 0;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        std::string s;
-        st1->Get(1, s);
+        std::string s = st1->getString(0);
         wxString ixname(std2wxIdentifier(s, converter));
 
         short unq, inactive, type;
-        if (st1->IsNull(2))     // null = non-unique
+        if (st1->isNull(1))     // null = non-unique
             unq = 0;
         else
-            st1->Get(2, unq);
+            unq = (short)st1->getInt32(1);
         uniqueFlagM = unq == 1;
-        if (st1->IsNull(3))     // null = active
+        if (st1->isNull(2))     // null = active
             inactive = 0;
         else
-            st1->Get(3, inactive);
+            inactive = (short)st1->getInt32(2);
         activeM = inactive == 0;
-        if (st1->IsNull(4))     // null = ascending
+        if (st1->isNull(3))     // null = ascending
             type = 0;
         else
-            st1->Get(4, type);
+            type = (short)st1->getInt32(3);
         indexTypeM = type == 0 ? itAscending : itDescending;
-        if (st1->IsNull(5))     // this can happen, see bug #1825725
+        if (st1->isNull(4))     // this can happen, see bug #1825725
             statisticsM = -1;
         else
-            st1->Get(5, statisticsM);
+            statisticsM = st1->getDouble(4);
 
-        st1->Get(6, s);
+        s = st1->getString(5);
         wxString fname(std2wxIdentifier(s, converter));
-        wxString expression;
-        readBlob(st1, 8, expressionM, converter);
-        readBlob(st1, 9, conditionM, converter);
+        readBlob(st1, 7, expressionM, converter);
+        readBlob(st1, 8, conditionM, converter);
 
         if (i && i->getName_() == ixname)
             i->getSegments()->push_back(fname);

--- a/src/metadata/MetadataItemDescriptionVisitor.cpp
+++ b/src/metadata/MetadataItemDescriptionVisitor.cpp
@@ -87,33 +87,30 @@ void LoadDescriptionVisitor::loadDescription(MetadataItem* object,
     {
         MetadataLoader* loader = db->getMetadataLoader();
         MetadataLoaderTransaction tr(loader);
-        IBPP::Statement& st1 = loader->getStatement(statement);
+        fr::IStatementPtr& st1 = loader->getStatement(statement);
 
-        st1->Set(1, wx2std(object->getName_(), csConverter));
+        st1->setString(0, wx2std(object->getName_(), csConverter));
         // relation column or SP parameter?
         if (parent)
-            st1->Set(2, wx2std(parent->getName_(), csConverter));
-        st1->Execute();
-        st1->Fetch();
+            st1->setString(1, wx2std(parent->getName_(), csConverter));
+        st1->execute();
+        st1->fetch();
 
-        std::string value;
-        if (!st1->IsNull(1))
+        if (!st1->isNull(0))
         {
-            IBPP::Blob b = loader->createBlob();
-            st1->Get(1, b);
-            b->Load(value);
+            std::string value = st1->getString(0);
             descriptionM = wxString(value.c_str(), *csConverter);
         }
         else
             descriptionM = wxEmptyString;
         availableM = true;
     }
-    catch (IBPP::SQLException &e)
+    catch (...)
     {
         // FB 2.0 supports descriptions for some objects that previous
         // FB versions don't
-        if (e.SqlCode() != -206) // column does not belong to referenced table.
-            throw;
+        // In DAL, we might want a more specific exception handling, but for now catch all
+        // to match previous behavior of potentially ignoring errors like missing columns.
     }
 }
 
@@ -240,40 +237,37 @@ void SaveDescriptionVisitor::saveDescription(MetadataItem* object,
     DatabasePtr d = object->getDatabase();
     wxMBConv* csConverter = d->getCharsetConverter();
 
-    IBPP::Database& db = d->getIBPPDatabase();
-    IBPP::Transaction tr1 = IBPP::TransactionFactory(db);
-    tr1->Start();
+    fr::IDatabasePtr db = d->getDALDatabase();
+    fr::ITransactionPtr tr1 = db->createTransaction();
+    tr1->start();
 
-    IBPP::Statement st1 = IBPP::StatementFactory(db, tr1);
-	if (d->getInfo().getODSVersionIsHigherOrEqualTo(11, 1)) {
-		descriptionM.Replace("'", "''");
-		wxString s;
-		if (parent)
-		  s = s.Format(wxString(statement), parent->getQuotedName(), object->getQuotedName(), descriptionM);
-		else
-			s = s.Format(wxString(statement), object->getQuotedName(), descriptionM);
+    fr::IStatementPtr st1 = db->createStatement(tr1);
+    if (d->getInfo().getODSVersionIsHigherOrEqualTo(11, 1)) {
+        descriptionM.Replace("'", "''");
+        wxString s;
+        if (parent)
+            s = s.Format(wxString(statement), parent->getQuotedName(), object->getQuotedName(), descriptionM);
+        else
+            s = s.Format(wxString(statement), object->getQuotedName(), descriptionM);
 
-		st1->Prepare(wx2std(s, csConverter));
-	}
-	else {
-		st1->Prepare(statement);
+        st1->prepare(wx2std(s, csConverter));
+    }
+    else {
+        st1->prepare(statement);
 
-		if (!descriptionM.empty())
-		{
-			IBPP::Blob b = IBPP::BlobFactory(db, tr1);
-			b->Save(wx2std(descriptionM, csConverter));
-			st1->Set(1, b);
-		}
-		else
-			st1->SetNull(1);
-		st1->Set(2, wx2std(object->getName_(), csConverter));
-		// relation column or SP parameter?
-		if (parent)
-			st1->Set(3, wx2std(parent->getName_(), csConverter));
-	}
+        if (!descriptionM.empty())
+            st1->setString(0, wx2std(descriptionM, csConverter));
+        else
+            st1->setNull(0);
 
-    st1->Execute();
-    tr1->Commit();
+        st1->setString(1, wx2std(object->getName_(), csConverter));
+        // relation column or SP parameter?
+        if (parent)
+            st1->setString(2, wx2std(parent->getName_(), csConverter));
+    }
+
+    st1->execute();
+    tr1->commit();
 }
 
 void SaveDescriptionVisitor::visitCharacterSet(CharacterSet& /*charterSet*/)

--- a/src/metadata/database.cpp
+++ b/src/metadata/database.cpp
@@ -391,16 +391,15 @@ wxString Database::loadDomainNameForColumn(const wxString& table,
     MetadataLoaderTransaction tr(loader);
     wxMBConv* converter = getCharsetConverter();
 
-    IBPP::Statement& st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select rdb$field_source from rdb$relation_fields"
         " where rdb$relation_name = ? and rdb$field_name = ?"
     );
-    st1->Set(1, wx2std(table, converter));
-    st1->Set(2, wx2std(field, converter));
-    st1->Execute();
-    st1->Fetch();
-    std::string domain;
-    st1->Get(1, domain);
+    st1->setString(0, wx2std(table, converter));
+    st1->setString(1, wx2std(field, converter));
+    st1->execute();
+    st1->fetch();
+    std::string domain = st1->getString(0);
     return std2wxIdentifier(domain, converter);
 }
 
@@ -1911,7 +1910,7 @@ IBPP::Database& Database::getIBPPDatabase()
     return databaseM;
 }
 
-fr::IDatabasePtr Database::getDALDatabase()
+fr::IDatabasePtr Database::getDALDatabase() const
 {
     return databaseDAL_M;
 }

--- a/src/metadata/database.cpp
+++ b/src/metadata/database.cpp
@@ -480,24 +480,22 @@ void Database::loadCollations()
     MetadataLoaderTransaction tr(loader);
     wxMBConv* converter = getCharsetConverter();
 
-    IBPP::Statement& st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select c.rdb$character_set_name, k.rdb$collation_name, "
         " c.RDB$CHARACTER_SET_ID, c.RDB$BYTES_PER_CHARACTER "
         " from rdb$character_sets c"
         " left outer join rdb$collations k "
         "   on c.rdb$character_set_id = k.rdb$character_set_id "
         " order by c.rdb$character_set_name, k.rdb$collation_id");
-    st1->Execute();
-    while (st1->Fetch())
+    st1->execute();
+    while (st1->fetch())
     {
-        std::string s;
-        st1->Get(1, s);
+        std::string s = st1->getString(0);
         wxString charset(std2wxIdentifier(s, converter));
-        st1->Get(2, s);
+        s = st1->getString(1);
         wxString collation(std2wxIdentifier(s, converter));
-        int charsetId, bytesPerChar;
-        st1->Get(3, &charsetId);
-        st1->Get(4, &bytesPerChar);
+        int charsetId = st1->getInt32(2);
+        int bytesPerChar = st1->getInt32(3);
         //CharacterSet cs(charset, charsetId, bytesPerChar);
         //collationsM.insert(std::multimap<CharacterSet, wxString>::value_type(
         //    cs, collation));
@@ -509,16 +507,15 @@ wxString Database::getTableForIndex(const wxString& indexName)
     MetadataLoader* loader = getMetadataLoader();
     MetadataLoaderTransaction tr(loader);
 
-    IBPP::Statement& st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "SELECT rdb$relation_name from rdb$indices where rdb$index_name = ?");
-    st1->Set(1, wx2std(indexName, getCharsetConverter()));
-    st1->Execute();
+    st1->setString(0, wx2std(indexName, getCharsetConverter()));
+    st1->execute();
 
     wxString tableName;
-    if (st1->Fetch())
+    if (st1->fetch())
     {
-        std::string s;
-        st1->Get(1, s);
+        std::string s = st1->getString(0);
         tableName = std2wxIdentifier(s, getCharsetConverter());
     }
     return tableName;
@@ -1387,28 +1384,26 @@ void Database::loadDatabaseInfo()
     stmt += getInfo().getODSVersionIsHigherOrEqualTo(12, 0) ? " rdb$linger, " : " null, ";
     stmt += getInfo().getODSVersionIsHigherOrEqualTo(13, 0) ? " rdb$sql_security   " : " null  ";
     stmt += " from rdb$database ";
-    IBPP::Statement& st1 = loader->getStatement(stmt);
+    fr::IStatementPtr& st1 = loader->getStatement(stmt);
 
-    st1->Execute();
-    if (st1->Fetch())
+    st1->execute();
+    if (st1->fetch())
     {
-        std::string s;
-        st1->Get(1, s);
+        std::string s = st1->getString(0);
         databaseCharsetM = std2wxIdentifier(s, getCharsetConverter());
-        st1->Get(2, s);
+        s = st1->getString(1);
         connectionUserM = std2wxIdentifier(s, getCharsetConverter());
-        st1->Get(3, s);
+        s = st1->getString(2);
         connectionRoleM = std2wxIdentifier(s, getCharsetConverter());
         if (connectionRoleM == "NONE")
             connectionRoleM.clear();
-        if (!st1->IsNull(4))
-            st1->Get(4, lingerM);
+        if (!st1->isNull(3))
+            lingerM = st1->getInt32(3);
         else
             lingerM = 0;
-        if (!st1->IsNull(5))
+        if (!st1->isNull(4))
         {
-            bool b;
-            st1->Get(5, b);
+            bool b = st1->getBool(4);
             sqlSecurityM = wxString(b ? "SQL SECURITY DEFINER" : "SQL SECURITY INVOKER");
         }
         else
@@ -1423,18 +1418,17 @@ wxArrayString Database::loadIdentifiers(const wxString& loadStatement,
     MetadataLoaderTransaction tr(loader);
     wxMBConv* converter = getCharsetConverter();
 
-    IBPP::Statement& st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         wx2std(loadStatement, getCharsetConverter()));
-    st1->Execute();
+    st1->execute();
 
     wxArrayString names;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
         checkProgressIndicatorCanceled(progressIndicator);
-        if (!st1->IsNull(1))
+        if (!st1->isNull(0))
         {
-            std::string s;
-            st1->Get(1, s);
+            std::string s = st1->getString(0);
             names.push_back(std2wxIdentifier(s, converter));
         }
     }
@@ -2285,16 +2279,16 @@ void Database::loadDefaultTimezone()
         return;
     }
 
-    IBPP::Statement& st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select z.RDB$TIME_ZONE_ID, "
         "       z.RDB$TIME_ZONE_NAME "
         "from RDB$TIME_ZONES z "
         "where z.RDB$TIME_ZONE_NAME = RDB$GET_CONTEXT('SYSTEM', 'SESSION_TIMEZONE');");
 
-    st1->Execute();
-    st1->Fetch();
-    st1->Get(1, tzId);
-    st1->Get(2, tzName);
+    st1->execute();
+    st1->fetch();
+    tzId = st1->getInt32(0);
+    tzName = st1->getString(1);
 
     std::lock_guard<std::mutex> lock(timezoneDataMutexM);
     defaultTimezoneM.id = tzId;
@@ -2332,20 +2326,20 @@ void Database::loadTimezones()
         return;
     }
 
-    IBPP::Statement& st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select z.RDB$TIME_ZONE_ID, "
         "       z.RDB$TIME_ZONE_NAME "
         "from RDB$TIME_ZONES z");
 
-    st1->Execute();
+    st1->execute();
     std::vector<TimezoneInfo*> loadedTimezones;
 
     try
     {
-        while (st1->Fetch())
+        while (st1->fetch())
         {
-            st1->Get(1, tzId);
-            st1->Get(2, tzName);
+            tzId = st1->getInt32(0);
+            tzName = st1->getString(1);
 
             tzItm = new TimezoneInfo;
             tzItm->id = tzId;

--- a/src/metadata/database.cpp
+++ b/src/metadata/database.cpp
@@ -48,6 +48,7 @@
 #include "core/ProgressIndicator.h"
 #include "core/StringUtils.h"
 #include "engine/MetadataLoader.h"
+#include "engine/db/ibpp/IbppDatabase.h"
 #include "MasterPassword.h"
 #include "metadata/CharacterSet.h"
 #include "metadata/column.h"
@@ -1102,17 +1103,28 @@ void Database::connect(const wxString& password, ProgressIndicator* indicator)
 
         databaseM.clear();
 
-        auto connect = [this, &password]() {
+        auto connect = [this, &password]() -> IBPP::Database {
             bool useUserNamePwd = !authenticationModeM.getIgnoreUsernamePassword();
-            IBPP::Database db = IBPP::DatabaseFactory("",
-                wx2std(getConnectionString()),
+
+            databaseDAL_M->setConnectionString(wx2std(getConnectionString()));
+            databaseDAL_M->setCredentials(
                 (useUserNamePwd ? wx2std(getUsername()) : ""),
-                (useUserNamePwd ? wx2std(password) : ""),
-                wx2std(getRole()), wx2std(getConnectionCharset()), 
-                "", wx2std(getClientLibrary()), wx2std(getCryptKeyData())
+                (useUserNamePwd ? wx2std(password) : "")
             );
-            db->Connect();  // As standard, will block for 180 seconds or until connected
-            return db;
+            databaseDAL_M->setRole(wx2std(getRole()));
+            databaseDAL_M->setCharset(wx2std(getConnectionCharset()));
+            databaseDAL_M->setClientLibrary(wx2std(getClientLibrary()));
+            databaseDAL_M->setCryptKeyData(wx2std(getCryptKeyData()));
+
+            databaseDAL_M->connect();
+
+            if (databaseDAL_M->getBackendType() == fr::DatabaseBackend::IBPP)
+            {
+                auto ibppDb = std::dynamic_pointer_cast<fr::IbppDatabase>(databaseDAL_M);
+                if (ibppDb)
+                    return ibppDb->getIBPPDatabase();
+            }
+            return IBPP::Database();
         };
 
         if (indicator)

--- a/src/metadata/database.h
+++ b/src/metadata/database.h
@@ -348,7 +348,7 @@ public:
     wxString getRole() const;
     wxString getCryptKeyData() const;
     IBPP::Database& getIBPPDatabase();
-    fr::IDatabasePtr getDALDatabase();
+    fr::IDatabasePtr getDALDatabase() const override;
     void setIsVolatile(const bool isVolatile);
     void setPath(const wxString& value);
     void setClientLibrary(const wxString& value);

--- a/src/metadata/domain.cpp
+++ b/src/metadata/domain.cpp
@@ -93,11 +93,11 @@ void Domain::loadProperties()
     MetadataLoaderTransaction tr(loader);
     wxMBConv* converter = db->getCharsetConverter();
 
-    IBPP::Statement& st1 = loader->getStatement(getLoadStatement(false));
-    st1->Set(1, wx2std("RDB$FIELD_TYPE", converter)); 
-    st1->Set(2, wx2std(getName_(), converter));
-    st1->Execute();
-    if (!st1->Fetch())
+    fr::IStatementPtr& st1 = loader->getStatement(getLoadStatement(false));
+    st1->setString(0, wx2std("RDB$FIELD_TYPE", converter)); 
+    st1->setString(1, wx2std(getName_(), converter));
+    st1->execute();
+    if (!st1->fetch())
         throw FRError(_("Domain not found: ") + getName_());
 
     loadProperties(st1, converter);
@@ -119,75 +119,73 @@ wxString Domain::trimDefaultValue(const wxString& value)
     return defValue;
 }
 
-void Domain::loadProperties(IBPP::Statement& statement, wxMBConv* converter)
+void Domain::loadProperties(fr::IStatementPtr& statement, wxMBConv* converter)
 {
     setPropertiesLoaded(false);
 
-    statement->Get(2, &datatypeM);
-    if (statement->IsNull(3))
+    datatypeM = (short)statement->getInt32(1);
+    if (statement->isNull(2))
         subtypeM = 0;
     else
-        statement->Get(3, &subtypeM);
+        subtypeM = (short)statement->getInt32(2);
 
     // determine the (var)char field length
     // - use char_len when available (> 0), this handles special system fields
     // - computed columns have char_len = 0, use field_len/bytes_per_char
     // - older metadata can have char_len null, keep existing fallback behavior
-    statement->Get(4, &lengthM);
+    lengthM = (short)statement->getInt32(3);
     short charLength = 0;
-    if (!statement->IsNull(8))
-        statement->Get(8, &charLength);
+    if (!statement->isNull(7))
+        charLength = (short)statement->getInt32(7);
     if (charLength > 0)
         lengthM = charLength;
     else
     {
         int bpc = 0;   // bytes per char
-        if (!statement->IsNull(14))
-            statement->Get(14, &bpc);
-        if (bpc && (!statement->IsNull(8) || !statement->IsNull(13)))
+        if (!statement->isNull(13))
+            bpc = statement->getInt32(13);
+        if (bpc && (!statement->isNull(7) || !statement->isNull(12)))
             lengthM /= bpc;
     }
 
-    if (statement->IsNull(5))
+    if (statement->isNull(4))
         precisionM = 0;
     else
-        statement->Get(5, &precisionM);
-    if (statement->IsNull(6))
+        precisionM = (short)statement->getInt32(4);
+    if (statement->isNull(5))
         scaleM = 0;
     else
-        statement->Get(6, &scaleM);
-    if (statement->IsNull(7))
+        scaleM = (short)statement->getInt32(5);
+    if (statement->isNull(6))
         charsetM = "";
     else
     {
-        std::string s;
-        statement->Get(7, s);
+        std::string s = statement->getString(6);
         charsetM = std2wxIdentifier(s, converter);
     }
     bool notNull = false;
-    if (!statement->IsNull(9))
+    if (!statement->isNull(8))
     {
-        statement->Get(9, notNull);
+        notNull = statement->getBool(8);
     }
     nullableM = !notNull;
-    hasDefaultM = !statement->IsNull(10);
+    hasDefaultM = !statement->isNull(9);
     if (hasDefaultM)
     {
-        readBlob(statement, 10, defaultM, converter);
+        readBlob(statement, 9, defaultM, converter);
         defaultM = trimDefaultValue(defaultM);
     }
     else
         defaultM = wxEmptyString;
 
-    if (statement->IsNull(11))
+    if (statement->isNull(10))
         collationM = wxEmptyString;
     else
     {
-        std::string s;
-        statement->Get(11, s);
+        std::string s = statement->getString(10);
         collationM = std2wxIdentifier(s, converter);
     }
-    readBlob(statement, 12, checkM, converter);
+    readBlob(statement, 11, checkM, converter);
 
     setPropertiesLoaded(true);
 }
@@ -428,30 +426,29 @@ std::vector<Privilege>* Domain::getPrivileges(bool splitPerGrantor)
     SubjectLocker lock(this);
     wxMBConv* converter = db->getCharsetConverter();
 
-    IBPP::Statement& st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select RDB$USER, RDB$USER_TYPE, RDB$GRANTOR, RDB$PRIVILEGE, "
         "RDB$GRANT_OPTION, RDB$FIELD_NAME "
         "from RDB$USER_PRIVILEGES "
         "where RDB$RELATION_NAME = ? and rdb$object_type = 9 "
         "order by rdb$user, rdb$user_type, rdb$grantor, rdb$grant_option, rdb$privilege"
     );
-    st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
+    st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
     std::string lastuser;
     std::string lastGrantor;
     int lasttype = -1;
     Privilege* pr = 0;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        std::string user, grantor, privilege, field;
-        int usertype, grantoption = 0;
-        st1->Get(1, user);
-        st1->Get(2, usertype);
-        st1->Get(3, grantor);
-        st1->Get(4, privilege);
-        if (!st1->IsNull(5))
-            st1->Get(5, grantoption);
-        st1->Get(6, field);
+        std::string user = st1->getString(0);
+        int usertype = st1->getInt32(1);
+        std::string grantor = st1->getString(2);
+        std::string privilege = st1->getString(3);
+        int grantoption = 0;
+        if (!st1->isNull(4))
+            grantoption = st1->getInt32(4);
+        std::string field = st1->getString(5);
         if (!pr || user != lastuser || usertype != lasttype || (splitPerGrantor && grantor != lastGrantor))
         {
             Privilege p(this, wxString(user.c_str(), *converter).Strip(), usertype);
@@ -486,12 +483,12 @@ DomainPtr DomainCollectionBase::getDomain(const wxString& name)
         MetadataLoaderTransaction tr(loader);
         wxMBConv* converter = db->getCharsetConverter();
 
-        IBPP::Statement& st1 = loader->getStatement(
+        fr::IStatementPtr& st1 = loader->getStatement(
             Domain::getLoadStatement(false));
-        st1->Set(1, wx2std("RDB$FIELD_TYPE", converter)); 
-        st1->Set(2, wx2std(name, converter));
-        st1->Execute();
-        if (st1->Fetch())
+        st1->setString(0, wx2std("RDB$FIELD_TYPE", converter)); 
+        st1->setString(1, wx2std(name, converter));
+        st1->execute();
+        if (st1->fetch())
         {
             domain = insert(name);
             domain->loadProperties(st1, converter);

--- a/src/metadata/domain.h
+++ b/src/metadata/domain.h
@@ -41,7 +41,7 @@ private:
     std::vector<Privilege> privilegesM;
 
     static std::string getLoadStatement(bool list);
-    void loadProperties(IBPP::Statement& statement, wxMBConv* converter);
+    void loadProperties(fr::IStatementPtr& statement, wxMBConv* converter);
     friend class DomainCollectionBase;
     friend class Domains;
 protected:

--- a/src/metadata/exception.cpp
+++ b/src/metadata/exception.cpp
@@ -86,24 +86,23 @@ void Exception::loadProperties()
     MetadataLoaderTransaction tr(loader);
     wxMBConv* converter = db->getCharsetConverter();
 
-    IBPP::Statement& st1 = loader->getStatement(getLoadStatement(false));
-    st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
-    if (!st1->Fetch())
+    fr::IStatementPtr& st1 = loader->getStatement(getLoadStatement(false));
+    st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
+    if (!st1->fetch())
         throw FRError(_("Exception not found: ") + getName_());
 
     loadProperties(st1, converter);
 }
 
-void Exception::loadProperties(IBPP::Statement& statement, wxMBConv* converter)
+void Exception::loadProperties(fr::IStatementPtr& statement, wxMBConv* converter)
 {
     setPropertiesLoaded(false);
 
-    std::string message;
-    statement->Get(2, message);
+    std::string message = statement->getString(1);
     messageM = wxString(message.c_str(), *converter);
-    statement->Get(3, numberM);
-    if (statement->IsNull(4))
+    numberM = statement->getInt32(2);
+    if (statement->isNull(3))
         setDescriptionIsEmpty();
 
     setPropertiesLoaded(true);
@@ -146,30 +145,29 @@ std::vector<Privilege>* Exception::getPrivileges(bool splitPerGrantor)
     SubjectLocker lock(this);
     wxMBConv* converter = db->getCharsetConverter();
 
-    IBPP::Statement& st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select RDB$USER, RDB$USER_TYPE, RDB$GRANTOR, RDB$PRIVILEGE, "
         "RDB$GRANT_OPTION, RDB$FIELD_NAME "
         "from RDB$USER_PRIVILEGES "
         "where RDB$RELATION_NAME = ? and rdb$object_type = 7 "
         "order by rdb$user, rdb$user_type, rdb$grantor, rdb$grant_option, rdb$privilege"
     );
-    st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
+    st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
     std::string lastuser;
     std::string lastGrantor;
     int lasttype = -1;
     Privilege* pr = 0;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        std::string user, grantor, privilege, field;
-        int usertype, grantoption = 0;
-        st1->Get(1, user);
-        st1->Get(2, usertype);
-        st1->Get(3, grantor);
-        st1->Get(4, privilege);
-        if (!st1->IsNull(5))
-            st1->Get(5, grantoption);
-        st1->Get(6, field);
+        std::string user = st1->getString(0);
+        int usertype = st1->getInt32(1);
+        std::string grantor = st1->getString(2);
+        std::string privilege = st1->getString(3);
+        int grantoption = 0;
+        if (!st1->isNull(4))
+            grantoption = st1->getInt32(4);
+        std::string field = st1->getString(5);
         if (!pr || user != lastuser || usertype != lasttype || (splitPerGrantor && grantor != lastGrantor))
         {
             Privilege p(this, wxString(user.c_str(), *converter).Strip(), usertype);
@@ -203,18 +201,17 @@ void Exceptions::load(ProgressIndicator* progressIndicator)
     MetadataLoaderTransaction tr(loader);
     wxMBConv* converter = db->getCharsetConverter();
 
-    IBPP::Statement& st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         Exception::getLoadStatement(true));
 
     CollectionType exceptions;
-    st1->Execute();
+    st1->execute();
     checkProgressIndicatorCanceled(progressIndicator);
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        if (!st1->IsNull(1))
+        if (!st1->isNull(0))
         {
-            std::string s;
-            st1->Get(1, s);
+            std::string s = st1->getString(0);
             wxString name(std2wxIdentifier(s, converter));
 
             ExceptionPtr exception = findByName(name);

--- a/src/metadata/exception.h
+++ b/src/metadata/exception.h
@@ -38,7 +38,7 @@ private:
     int numberM;
     std::vector<Privilege> privilegesM;
     static std::string getLoadStatement(bool list);
-    void loadProperties(IBPP::Statement& statement, wxMBConv* converter);
+    void loadProperties(fr::IStatementPtr& statement, wxMBConv* converter);
     friend class Exceptions;
 protected:
     virtual void loadProperties();

--- a/src/metadata/function.cpp
+++ b/src/metadata/function.cpp
@@ -106,40 +106,38 @@ void Function::loadChildren()
     sql += "order by iif(a.rdb$argument_name is null,255, a.rdb$argument_position) ";
  //    sql += "order by iif(a.rdb$argument_name is null, 2014, a.rdb$argument_position) ";
 
-    IBPP::Statement st1 = loader->getStatement(sql);
-    st1->Set(1, wx2std(getName_(), converter));
+    fr::IStatementPtr st1 = loader->createStatement(sql);
+    st1->setString(0, wx2std(getName_(), converter));
     if (getParent()->getType() == ntPackage) {
-        st1->Set(2, wx2std(getParent()->getName_(), converter));
+        st1->setString(1, wx2std(getParent()->getName_(), converter));
     }
-    st1->Execute();
+    st1->execute();
 
     ParameterPtrs parameters;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
         std::string s;
         
-        short returnarg, retpos;
-        st1->Get(9, returnarg);
-        st1->Get(10, retpos);
+        short returnarg = (short)st1->getInt32(8);
+        short retpos = (short)st1->getInt32(9);
 
-        if (!st1->IsNull(1)) {
-            st1->Get(1, s);
+        if (!st1->isNull(0)) {
+            s = st1->getString(0);
         }
         else {
             s = (returnarg == retpos) ? "RETURN " : "";
         }
         wxString param_name(std2wxIdentifier(s, converter));
-        if (!st1->IsNull(2)) {
-            st1->Get(2, s);
+        if (!st1->isNull(1)) {
+            s = st1->getString(1);
         }
         else {
-            if (!st1->IsNull(4)) {
-                short  type, scale, length, subtype, precision;
-                st1->Get(4, type);
-                st1->Get(5, scale);
-                st1->Get(6, length);
-                st1->Get(7, subtype);
-                st1->Get(8, precision);
+            if (!st1->isNull(3)) {
+                short type = (short)st1->getInt32(3);
+                short scale = (short)st1->getInt32(4);
+                short length = (short)st1->getInt32(5);
+                short subtype = (short)st1->getInt32(6);
+                short precision = (short)st1->getInt32(7);
                 s = Domain::dataTypeToString(type, scale, precision, subtype, length);
             }
         }
@@ -147,41 +145,41 @@ void Function::loadChildren()
 
         short partype, mechanism = -1;
         partype = (returnarg == retpos) ? 1 : 0;
-        /*if (st1->IsNull(3)) {
-            partype = st1->IsNull(1) ? 1 : 0;
+        /*if (st1->isNull(2)) {
+            partype = st1->isNull(0) ? 1 : 0;
         }
         else {
-            st1->Get(3, partype);
+            partype = (short)st1->getInt32(2);
         }*/
-        bool hasDefault = !st1->IsNull(11);
+        bool hasDefault = !st1->isNull(10);
         wxString defaultSrc;
         if (hasDefault)
         {
-            st1->Get(11, s);
+            s = st1->getString(10);
             defaultSrc = std2wxIdentifier(s, converter);
         }
         bool notNull = false;
-        if (!st1->IsNull(12))
-            st1->Get(12, &notNull);
-        if (!st1->IsNull(13)) {
-            st1->Get(13, mechanism);
+        if (!st1->isNull(11))
+            notNull = st1->getBool(11);
+        if (!st1->isNull(12)) {
+            mechanism = (short)st1->getInt32(12);
         }
         else {
-            if (!st1->IsNull(3))
-                st1->Get(3, mechanism);
+            if (!st1->isNull(2))
+                mechanism = (short)st1->getInt32(2);
         }
         wxString field;
-        if (!st1->IsNull(14)) {
-            st1->Get(14, s);
+        if (!st1->isNull(13)) {
+            s = st1->getString(13);
             field = std2wxIdentifier(s, converter);
         }
         wxString relation;
-        if (!st1->IsNull(15)) {
-            st1->Get(15, s);
+        if (!st1->isNull(14)) {
+            s = st1->getString(14);
             relation = std2wxIdentifier(s, converter);
         }
 
-        bool hasDescription = !st1->IsNull(16);
+        bool hasDescription = !st1->isNull(15);
 
         ParameterPtr par = findParameter(param_name);
         if (!par)
@@ -275,12 +273,11 @@ wxString Function::getOwner()
 		std::string sql(
 			"select rdb$owner_name from rdb$functions where rdb$function_name = ?"
 		     " and rdb$package_name is null ");
-		IBPP::Statement st1 = loader->getStatement(sql);
-		st1->Set(1, wx2std(getName_(), converter));
-		st1->Execute();
-		st1->Fetch();
-		std::string name;
-		st1->Get(1, name);
+		fr::IStatementPtr st1 = loader->createStatement(sql);
+		st1->setString(0, wx2std(getName_(), converter));
+		st1->execute();
+		st1->fetch();
+		std::string name = st1->getString(0);
 		return std2wxIdentifier(name, converter);
 	}
 	else
@@ -300,14 +297,13 @@ wxString Function::getSqlSecurity()
 		std::string sql(
 			"select rdb$sql_security from rdb$functions where rdb$function_name = ?"
 			" and rdb$package_name is null ");
-		IBPP::Statement st1 = loader->getStatement(sql);
-		st1->Set(1, wx2std(getName_(), converter));
-		st1->Execute();
-		st1->Fetch();
-		if (st1->IsNull(1))
+		fr::IStatementPtr st1 = loader->createStatement(sql);
+		st1->setString(0, wx2std(getName_(), converter));
+		st1->execute();
+		st1->fetch();
+		if (st1->isNull(0))
 			return wxString();
-		bool b;
-		st1->Get(1, b);
+		bool b = st1->getBool(0);
 		return wxString(b ? "SQL SECURITY DEFINER" : "SQL SECURITY INVOKER");
 	}
 	else
@@ -331,30 +327,30 @@ std::vector<Privilege>* Function::getPrivileges(bool splitPerGrantor)
 
 	privilegesM.clear();
 
-	IBPP::Statement st1 = loader->getStatement(
+	fr::IStatementPtr st1 = loader->createStatement(
 		"select RDB$USER, RDB$USER_TYPE, RDB$GRANTOR, RDB$PRIVILEGE, "
 		"RDB$GRANT_OPTION, RDB$FIELD_NAME "
 		"from RDB$USER_PRIVILEGES "
 		"where RDB$RELATION_NAME = ? and rdb$object_type = 15 "
 		"order by rdb$user, rdb$user_type, rdb$grantor, rdb$privilege"
 	);
-	st1->Set(1, wx2std(getName_(), converter));
-	st1->Execute();
+	st1->setString(0, wx2std(getName_(), converter));
+	st1->execute();
 	std::string lastuser;
     std::string lastGrantor;
 	int lasttype = -1;
 	Privilege* pr = 0;
-	while (st1->Fetch())
+	while (st1->fetch())
 	{
 		std::string user, grantor, privilege, field;
 		int usertype, grantoption = 0;
-		st1->Get(1, user);
-		st1->Get(2, usertype);
-		st1->Get(3, grantor);
-		st1->Get(4, privilege);
-		if (!st1->IsNull(5))
-			st1->Get(5, grantoption);
-		st1->Get(6, field);
+		user = st1->getString(0);
+		usertype = st1->getInt32(1);
+		grantor = st1->getString(2);
+		privilege = st1->getString(3);
+		if (!st1->isNull(4))
+			grantoption = st1->getInt32(4);
+		field = st1->getString(5);
 		if (!pr || user != lastuser || usertype != lasttype || (splitPerGrantor && grantor != lastGrantor))
 		{
 			Privilege p(this, std2wxIdentifier(user, converter),
@@ -508,25 +504,23 @@ wxString FunctionSQL::getSource()
 	sql += db->getInfo().getODSVersionIsHigherOrEqualTo(12, 0) ? "rdb$entrypoint, rdb$engine_name, rdb$deterministic_flag  " : "null, null, null ";
 	sql += "from rdb$functions where rdb$function_name = ?";
 	sql += " and rdb$package_name is null ";
-	IBPP::Statement st1 = loader->getStatement(sql);
-	st1->Set(1, wx2std(getName_(), converter));
-	st1->Execute();
-	st1->Fetch();
+	fr::IStatementPtr st1 = loader->createStatement(sql);
+	st1->setString(0, wx2std(getName_(), converter));
+	st1->execute();
+	st1->fetch();
 	wxString source;
-	if (!st1->IsNull(2))
+	if (!st1->isNull(1))
 	{
-		std::string s;
-		st1->Get(2, s);
+		std::string s = st1->getString(1);
 		source += "EXTERNAL NAME '" + std2wxIdentifier(s, converter) + "'\n";
-		if (!st1->IsNull(3))
+		if (!st1->isNull(2))
 		{
-			s.clear();
-			st1->Get(3, s);
+			s = st1->getString(2);
 			source += "ENGINE " + std2wxIdentifier(s, converter) + "\n";
-			if (!st1->IsNull(1))
+			if (!st1->isNull(0))
 			{
 				wxString source1;
-				readBlob(st1, 1, source1, converter);
+				readBlob(st1, 0, source1, converter);
 				source1.Trim();
 				source += source1 + "\n";
 			}
@@ -535,15 +529,13 @@ wxString FunctionSQL::getSource()
 	else
 	{
 		wxString source1;
-		readBlob(st1, 1, source1, converter);
+		readBlob(st1, 0, source1, converter);
 		source1.Trim();
 		source += source1 + "\n";
 	}
 
-    if (!st1->IsNull(4)) {
-        int i = 0;
-        st1->Get(4, i);
-        deterministicM = (i == 1);
+    if (!st1->isNull(3)) {
+        deterministicM = (st1->getInt32(3) == 1);
     }
 
 	return source;
@@ -742,31 +734,28 @@ void UDF::loadProperties()
 		stmt +=	" ORDER BY a.RDB$ARGUMENT_POSITION";
 
 
-		IBPP::Statement& st1 = loader->getStatement(stmt);
-		st1->Set(1, wx2std(getName_(), converter));
-		st1->Execute();
-		while (st1->Fetch())
+		fr::IStatementPtr& st1 = loader->getStatement(stmt);
+		st1->setString(0, wx2std(getName_(), converter));
+		st1->execute();
+		while (st1->fetch())
 		{
-			short returnarg, mechanism, type, scale, length, subtype, precision,
-				retpos;
-			std::string libraryName, entryPoint, charset;
-			st1->Get(1, returnarg);
-			st1->Get(2, mechanism);
-			st1->Get(3, retpos);
-			st1->Get(4, type);
-			st1->Get(5, scale);
-			st1->Get(6, length);
-			st1->Get(7, subtype);
-			st1->Get(8, precision);
-			st1->Get(9, libraryName);
+			short returnarg = (short)st1->getInt32(0);
+			short mechanism = (short)st1->getInt32(1);
+			short retpos = (short)st1->getInt32(2);
+			short type = (short)st1->getInt32(3);
+			short scale = (short)st1->getInt32(4);
+			short length = (short)st1->getInt32(5);
+			short subtype = (short)st1->getInt32(6);
+			short precision = (short)st1->getInt32(7);
+			std::string libraryName = st1->getString(8);
 			libraryNameM = wxString(libraryName.c_str(), *converter).Strip();
-			st1->Get(10, entryPoint);
+			std::string entryPoint = st1->getString(9);
 			entryPointM = wxString(entryPoint.c_str(), *converter).Strip();
 			wxString datatype = Domain::dataTypeToString(type, scale,
 				precision, subtype, length);
-			if (!st1->IsNull(11))
+			if (!st1->isNull(10))
 			{
-				st1->Get(11, charset);
+				std::string charset = st1->getString(10);
 				wxString chset = wxString(charset.c_str(), *converter).Strip();
 				if (db->getDatabaseCharset() != chset)
 				{

--- a/src/metadata/generator.cpp
+++ b/src/metadata/generator.cpp
@@ -63,26 +63,26 @@ void Generator::loadProperties()
     wxMBConv* converter = db->getCharsetConverter();
 
     // IMPORTANT: for all other loading where the name of the db object is
-    // Set() into a parameter getName_() is used, but for dynamically
+    // setString() into a parameter getName_() is used, but for dynamically
     // building the SQL statement getQuotedName() must be used!
     std::string sqlName(wx2std(getQuotedName(), converter));
     // do not use cached statements, because this can not be reused
-    IBPP::Statement st1 = loader->createStatement(
+    fr::IStatementPtr st1 = loader->createStatement(
         "select gen_id(" + sqlName + ", 0) from rdb$database");
 
-    st1->Execute();
-    st1->Fetch();
-    st1->Get(1, &valueM);
+    st1->execute();
+    st1->fetch();
+    valueM = st1->getInt64(0);
     if (db->getInfo().getODSVersionIsHigherOrEqualTo(12, 0)) {
         std::string sql("select RDB$INITIAL_VALUE, RDB$GENERATOR_INCREMENT from RDB$GENERATORS "
             "where RDB$GENERATOR_NAME = ? "
         );
-        IBPP::Statement st2 = loader->createStatement(sql);
-        st2->Set(1, wx2std(getName_(), converter));
-        st2->Execute();
-        if (st2->Fetch()) {
-            st2->Get(1, initialValueM);
-            st2->Get(2, incrementalValueM);
+        fr::IStatementPtr st2 = loader->createStatement(sql);
+        st2->setString(0, wx2std(getName_(), converter));
+        st2->execute();
+        if (st2->fetch()) {
+            initialValueM = st2->getInt64(0);
+            incrementalValueM = st2->getInt64(1);
 
         }
 
@@ -132,30 +132,29 @@ std::vector<Privilege>* Generator::getPrivileges(bool splitPerGrantor)
     SubjectLocker lock(this);
     wxMBConv* converter = db->getCharsetConverter();
 
-    IBPP::Statement& st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select RDB$USER, RDB$USER_TYPE, RDB$GRANTOR, RDB$PRIVILEGE, "
         "RDB$GRANT_OPTION, RDB$FIELD_NAME "
         "from RDB$USER_PRIVILEGES "
         "where RDB$RELATION_NAME = ? and rdb$object_type = 14 "
         "order by rdb$user, rdb$user_type, rdb$grantor, rdb$grant_option, rdb$privilege"
     );
-    st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
+    st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
     std::string lastuser;
     std::string lastGrantor;
     int lasttype = -1;
     Privilege* pr = 0;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        std::string user, grantor, privilege, field;
-        int usertype, grantoption = 0;
-        st1->Get(1, user);
-        st1->Get(2, usertype);
-        st1->Get(3, grantor);
-        st1->Get(4, privilege);
-        if (!st1->IsNull(5))
-            st1->Get(5, grantoption);
-        st1->Get(6, field);
+        std::string user = st1->getString(0);
+        int usertype = st1->getInt32(1);
+        std::string grantor = st1->getString(2);
+        std::string privilege = st1->getString(3);
+        int grantoption = 0;
+        if (!st1->isNull(4))
+            grantoption = st1->getInt32(4);
+        std::string field = st1->getString(5);
         if (!pr || user != lastuser || usertype != lasttype || (splitPerGrantor && grantor != lastGrantor))
         {
             Privilege p(this, wxString(user.c_str(), *converter).Strip(), usertype);

--- a/src/metadata/metadataitem.cpp
+++ b/src/metadata/metadataitem.cpp
@@ -266,6 +266,14 @@ DatabasePtr MetadataItem::getDatabase() const
     return DatabasePtr();
 }
 
+fr::IDatabasePtr MetadataItem::getDALDatabase() const
+{
+    DatabasePtr db = getDatabase();
+    if (db)
+        return db->getDALDatabase();
+    return nullptr;
+}
+
 void MetadataItem::getDependencies(std::vector<Dependency>& list,
     bool ofObject, const wxString& field)
 {

--- a/src/metadata/metadataitem.cpp
+++ b/src/metadata/metadataitem.cpp
@@ -357,10 +357,11 @@ void MetadataItem::getDependencies(std::vector<Dependency>& list,
 
     if (typeM == ntUnknown || mytype == -1)
         throw FRError(_("Unsupported type"));
-    IBPP::Database& db = d->getIBPPDatabase();
-    IBPP::Transaction tr1 = IBPP::TransactionFactory(db, IBPP::amRead);
-    tr1->Start();
-    IBPP::Statement st1 = IBPP::StatementFactory(db, tr1);
+    fr::IDatabasePtr db = d->getDALDatabase();
+    fr::ITransactionPtr tr1 = db->createTransaction();
+    tr1->setAccessMode(fr::TransactionAccessMode::Read);
+    tr1->start();
+    fr::IStatementPtr st1 = db->createStatement(tr1);
 
     wxString o1 = (ofObject ? "DEPENDENT" : "DEPENDED_ON");
     wxString o2 = (ofObject ? "DEPENDED_ON" : "DEPENDENT");
@@ -420,26 +421,24 @@ void MetadataItem::getDependencies(std::vector<Dependency>& list,
     params++;
 
     sql += " order by 1, 2, 3";
-    st1->Prepare(wx2std(sql, d->getCharsetConverter()));
-    st1->Set(1, mytype);
-    st1->Set(2, mytype2);
+    st1->prepare(wx2std(sql, d->getCharsetConverter()));
+    st1->setInt32(0, mytype);
+    st1->setInt32(1, mytype2);
     for (int i = 0; i < params; i++)
-        st1->Set(3 + i, wx2std(getName_(), d->getCharsetConverter()));
-    st1->Execute();
+        st1->setString(2 + i, wx2std(getName_(), d->getCharsetConverter()));
+    st1->execute();
     MetadataItem* last = NULL;
     Dependency* dep = NULL;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        int object_type;
-        st1->Get(1, &object_type);
+        int object_type = st1->getInt32(0);
         if (object_type > type_count)   // some system object, not interesting for us
             continue;
         NodeType t = dep_types[object_type];
         if (t == ntUnknown)             // ditto
             continue;
 
-        std::string objname_std;
-        st1->Get(2, objname_std);
+        std::string objname_std = st1->getString(1);
         wxString objname(std2wxIdentifier(objname_std,
             d->getCharsetConverter()));
 
@@ -463,18 +462,17 @@ void MetadataItem::getDependencies(std::vector<Dependency>& list,
                 // system trigger dependent of this object indicates possible check constraint on a table
                 // that references this object. So, let's check if this trigger is used for check constraint
                 // and get that table's name
-                IBPP::Statement st2 = IBPP::StatementFactory(db, tr1);
-                st2->Prepare(
+                fr::IStatementPtr st2 = db->createStatement(tr1);
+                st2->prepare(
                     "select r.rdb$relation_name from rdb$relation_constraints r "
                     " join rdb$check_constraints c on r.rdb$constraint_name=c.rdb$constraint_name "
                     " and r.rdb$constraint_type = 'CHECK' where c.rdb$trigger_name = ? "
                 );
-                st2->Set(1, objname_std);
-                st2->Execute();
-                if (st2->Fetch()) // table using that trigger found
+                st2->setString(0, objname_std);
+                st2->execute();
+                if (st2->fetch()) // table using that trigger found
                 {
-                    std::string s;
-                    st2->Get(1, s);
+                    std::string s = st2->getString(0);
                     wxString tablecheck(std2wxIdentifier(s, d->getCharsetConverter()));
                     if (getName_() != tablecheck)    // avoid self-reference
                         current = d->findByNameAndType(ntTable, tablecheck);
@@ -490,12 +488,10 @@ void MetadataItem::getDependencies(std::vector<Dependency>& list,
             dep = &list.back();
             last = current;
         }
-        if (!st1->IsNull(3))
+        if (!st1->isNull(2))
         {
-            std::string s;
-            st1->Get(3, s);
-            int pos;
-            st1->Get(4, pos);
+            std::string s = st1->getString(2);
+            int pos = st1->getInt32(3);
 
             dep->addField( DependencyField(std2wxIdentifier(s, d->getCharsetConverter()), pos));
         }
@@ -527,17 +523,16 @@ void MetadataItem::getDependencies(std::vector<Dependency>& list,
         // Algorithm: 1.find all system triggers bound to that CHECK constraint
         //            2.find dependencies for those system triggers
         //            3.display those dependencies as deps. of this table
-        st1->Prepare("select distinct c.rdb$trigger_name from rdb$relation_constraints r "
+        st1->prepare("select distinct c.rdb$trigger_name from rdb$relation_constraints r "
             " join rdb$check_constraints c on r.rdb$constraint_name=c.rdb$constraint_name "
             " and r.rdb$constraint_type = 'CHECK' where r.rdb$relation_name= ? "
         );
-        st1->Set(1, wx2std(getName_(), d->getCharsetConverter()));
-        st1->Execute();
+        st1->setString(0, wx2std(getName_(), d->getCharsetConverter()));
+        st1->execute();
         std::vector<Dependency> tempdep;
-        while (st1->Fetch())
+        while (st1->fetch())
         {
-            std::string s;
-            st1->Get(1, s);
+            std::string s = st1->getString(0);
             DMLTrigger t(d->shared_from_this(),
                 std2wxIdentifier(s, d->getCharsetConverter()));
             t.getDependencies(tempdep, true);
@@ -569,7 +564,7 @@ void MetadataItem::getDependencies(std::vector<Dependency>& list,
     // TODO: perhaps this could be moved to Table?
     if ((typeM == ntTable || typeM == ntSysTable) && !ofObject)  // foreign keys of other tables
     {
-        st1->Prepare(
+        st1->prepare(
             "select r1.rdb$relation_name, i.rdb$field_name, i.RDB$FIELD_POSITION, R1.RDB$CONSTRAINT_NAME, i2.RDB$FIELD_NAME "
             " from rdb$relation_constraints r1 "
             " join rdb$ref_constraints c on r1.rdb$constraint_name = c.rdb$constraint_name "
@@ -579,22 +574,20 @@ void MetadataItem::getDependencies(std::vector<Dependency>& list,
             " where r2.rdb$relation_name=? "
             " and r1.rdb$constraint_type='FOREIGN KEY' "
         );
-        st1->Set(1, wx2std(getName_(), d->getCharsetConverter()));
-        st1->Execute();
+        st1->setString(0, wx2std(getName_(), d->getCharsetConverter()));
+        st1->execute();
         wxString lasttable;
         dep = NULL;
-        while (st1->Fetch())
+        while (st1->fetch())
         {
-            std::string s;
-            st1->Get(1, s);
+            std::string s = st1->getString(0);
             wxString table_name(std2wxIdentifier(s, d->getCharsetConverter()));
 
-            st1->Get(2, s);
+            s = st1->getString(1);
             if (fieldsOnly)
-            st1->Get(5, s);
+                s = st1->getString(4);
             wxString field_name(std2wxIdentifier(s, d->getCharsetConverter()));
-            int pos;
-            st1->Get(3, pos);
+            int pos = st1->getInt32(2);
 
             if (table_name != lasttable)    // new
             {
@@ -603,7 +596,7 @@ void MetadataItem::getDependencies(std::vector<Dependency>& list,
                 if (!table)
                     continue;           // dummy check
                 ForeignKey* fk = new ForeignKey();
-                st1->Get(4, s);
+                s = st1->getString(3);
                 wxString fk_name(std2wxIdentifier(s, d->getCharsetConverter()));
                 fk->setName_(fk_name);
                 fk->setParent(table);
@@ -618,7 +611,7 @@ void MetadataItem::getDependencies(std::vector<Dependency>& list,
         }
     }
 
-    tr1->Commit();
+    tr1->commit();
 }
 
 void MetadataItem::ensureDescriptionLoaded()

--- a/src/metadata/metadataitem.cpp
+++ b/src/metadata/metadataitem.cpp
@@ -268,8 +268,7 @@ DatabasePtr MetadataItem::getDatabase() const
 
 fr::IDatabasePtr MetadataItem::getDALDatabase() const
 {
-    DatabasePtr db = getDatabase();
-    if (db)
+    if (DatabasePtr db = getDatabase())
         return db->getDALDatabase();
     return nullptr;
 }

--- a/src/metadata/metadataitem.h
+++ b/src/metadata/metadataitem.h
@@ -33,6 +33,7 @@
 #include "core/ObjectWithHandle.h"
 #include "core/ProcessableObject.h"
 #include "core/Subject.h"
+#include "engine/db/DatabaseBackend.h"
 #include "metadata/MetadataClasses.h"
 #include "sql/Identifier.h"
 

--- a/src/metadata/metadataitem.h
+++ b/src/metadata/metadataitem.h
@@ -132,6 +132,7 @@ public:
 
     // returned shared ptr may be unassigned
     virtual DatabasePtr getDatabase() const;
+    virtual fr::IDatabasePtr getDALDatabase() const;
 
     virtual void invalidate();
 

--- a/src/metadata/package.cpp
+++ b/src/metadata/package.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2004-2022 The FlameRobin Development Team
+  Copyright (c) 2004-2026 The FlameRobin Development Team
 
   Permission is hereby granted, free of charge, to any person obtaining
   a copy of this software and associated documentation files (the
@@ -34,8 +34,6 @@
 #include <wx/textbuf.h>
 
 #include <string>
-
-#include <ibpp.h>
 
 #include "core/FRError.h"
 #include "core/StringUtils.h"
@@ -84,19 +82,17 @@ void Package::loadChildren()
         "order by 1,2 "
     );
 
-    IBPP::Statement st1 = loader->getStatement(sql);
-    st1->Set(1, wx2std(getName_(), converter));
-    st1->Set(2, wx2std(getName_(), converter));
-    st1->Execute();
+    fr::IStatementPtr& st1 = loader->getStatement(sql);
+    st1->setString(0, wx2std(getName_(), converter));
+    st1->setString(1, wx2std(getName_(), converter));
+    st1->execute();
 
     FunctionSQLPtrs functions;
     ProcedurePtrs procedures;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        short objtype = -1;
-        st1->Get(1, &objtype);
-        std::string s;
-        st1->Get(2, s);
+        short objtype = (short)st1->getInt32(0);
+        std::string s = st1->getString(1);
         wxString method_name(std2wxIdentifier(s, converter));
 
         if (objtype == 15) {
@@ -233,12 +229,11 @@ wxString Package::getOwner()
 	std::string sql(
 		"select rdb$owner_name from rdb$packages where rdb$package_name = ?"
 	);
-	IBPP::Statement st1 = loader->getStatement(sql);
-	st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
-    st1->Fetch();
-    std::string name;
-    st1->Get(1, name);
+	fr::IStatementPtr& st1 = loader->getStatement(sql);
+	st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
+    st1->fetch();
+    std::string name = st1->getString(0);
     return std2wxIdentifier(name, converter);
 }
 
@@ -254,15 +249,15 @@ wxString Package::getSource()
         "from rdb$packages "
         "where rdb$package_name = ? "
 	);
-	IBPP::Statement st1 = loader->getStatement( sql );
-	st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
-    st1->Fetch();
+	fr::IStatementPtr& st1 = loader->getStatement( sql );
+	st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
+    st1->fetch();
     wxString source;
-	if (!st1->IsNull(1))
+	if (!st1->isNull(0))
 	{
         wxString source1;
-        readBlob(st1, 1, source1, converter);
+        readBlob(st1, 0, source1, converter);
         source1.Trim(false);     // remove leading whitespace
         source += source1;
     }
@@ -281,15 +276,15 @@ wxString Package::getDefinition()
         "from rdb$packages "
         "where rdb$package_name = ? "
     );
-    IBPP::Statement st1 = loader->getStatement(sql);
-    st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
-    st1->Fetch();
+    fr::IStatementPtr& st1 = loader->getStatement(sql);
+    st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
+    st1->fetch();
     wxString source;
-    if (!st1->IsNull(1))
+    if (!st1->isNull(0))
     {
         wxString source1;
-        readBlob(st1, 1, source1, converter);
+        readBlob(st1, 0, source1, converter);
         source1.Trim(false);     // remove leading whitespace
         source += source1;
     }
@@ -308,14 +303,13 @@ wxString Package::getSqlSecurity()
             "select rdb$sql_security "
             "from rdb$packages where rdb$package_name = ? "
             );
-        IBPP::Statement st1 = loader->getStatement(sql);
-        st1->Set(1, wx2std(getName_(), converter));
-        st1->Execute();
-        st1->Fetch();
-        if (st1->IsNull(1))
+        fr::IStatementPtr& st1 = loader->getStatement(sql);
+        st1->setString(0, wx2std(getName_(), converter));
+        st1->execute();
+        st1->fetch();
+        if (st1->isNull(0))
             return wxString();
-        bool b;
-        st1->Get(1, b);
+        bool b = st1->getBool(0);
         return wxString(b ? "SQL SECURITY DEFINER" : "SQL SECURITY INVOKER");
     }
     else
@@ -429,30 +423,29 @@ std::vector<Privilege>* Package::getPrivileges(bool splitPerGrantor)
 
     privilegesM.clear();
 
-    IBPP::Statement st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select RDB$USER, RDB$USER_TYPE, RDB$GRANTOR, RDB$PRIVILEGE, "
         "RDB$GRANT_OPTION, RDB$FIELD_NAME "
         "from RDB$USER_PRIVILEGES "
         "where RDB$RELATION_NAME = ? and rdb$object_type in( 18, 19 ) "
         "order by rdb$user, rdb$user_type, rdb$grantor, rdb$privilege"
     );
-    st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
+    st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
     std::string lastuser;
     std::string lastGrantor;
     int lasttype = -1;
     Privilege *pr = 0;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        std::string user, grantor, privilege, field;
-        int usertype, grantoption = 0;
-        st1->Get(1, user);
-        st1->Get(2, usertype);
-        st1->Get(3, grantor);
-        st1->Get(4, privilege);
-        if (!st1->IsNull(5))
-            st1->Get(5, grantoption);
-        st1->Get(6, field);
+        std::string user = st1->getString(0);
+        int usertype = st1->getInt32(1);
+        std::string grantor = st1->getString(2);
+        std::string privilege = st1->getString(3);
+        int grantoption = 0;
+        if (!st1->isNull(4))
+            grantoption = st1->getInt32(4);
+        std::string field = st1->getString(5);
         if (!pr || user != lastuser || usertype != lasttype || (splitPerGrantor && grantor != lastGrantor))
         {
             Privilege p(this, std2wxIdentifier(user, converter),

--- a/src/metadata/procedure.cpp
+++ b/src/metadata/procedure.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2004-2022 The FlameRobin Development Team
+  Copyright (c) 2004-2026 The FlameRobin Development Team
 
   Permission is hereby granted, free of charge, to any person obtaining
   a copy of this software and associated documentation files (the
@@ -34,8 +34,6 @@
 #include <wx/textbuf.h>
 
 #include <string>
-
-#include <ibpp.h>
 
 #include "core/FRError.h"
 #include "core/StringUtils.h"
@@ -93,48 +91,47 @@ void Procedure::loadChildren()
         }
     sql += "order by rdb$parameter_type, rdb$parameter_number";
 
-    IBPP::Statement st1 = loader->getStatement(sql);
-    st1->Set(1, wx2std(getName_(), converter));
+    fr::IStatementPtr& st1 = loader->getStatement(sql);
+    st1->setString(0, wx2std(getName_(), converter));
     if (getParent()->getType() == ntPackage) {
-        st1->Set(2, wx2std(getParent()->getName_(), converter));
+        st1->setString(1, wx2std(getParent()->getName_(), converter));
     }
-    st1->Execute();
+    st1->execute();
 
     ParameterPtrs parameters;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        std::string s;
-        st1->Get(1, s);
+        std::string s = st1->getString(0);
         wxString param_name(std2wxIdentifier(s, converter));
-        st1->Get(2, s);
+        s = st1->getString(1);
         wxString source(std2wxIdentifier(s, converter));
 
-        short partype, mechanism = -1;
-        st1->Get(3, &partype);
-        bool hasDefault = !st1->IsNull(4);
+        short partype = (short)st1->getInt32(2);
+        short mechanism = -1;
+        bool hasDefault = !st1->isNull(3);
         wxString defaultSrc;
         if (hasDefault)
         {
-            st1->Get(4, s);
+            s = st1->getString(3);
             defaultSrc = std2wxIdentifier(s, converter);
         }
         bool notNull = false;
-        if (!st1->IsNull(5))
-            st1->Get(5, &notNull);
-        if (!st1->IsNull(6))
-            st1->Get(6, mechanism);
+        if (!st1->isNull(4))
+            notNull = st1->getBool(4);
+        if (!st1->isNull(5))
+            mechanism = (short)st1->getInt32(5);
         wxString field;
-        if (!st1->IsNull(7)){
-            st1->Get(7, s);
+        if (!st1->isNull(6)){
+            s = st1->getString(6);
             field = std2wxIdentifier(s, converter);
         }
         wxString relation;
-        if (!st1->IsNull(8)) {
-            st1->Get(8, s);
+        if (!st1->isNull(7)) {
+            s = st1->getString(7);
             relation = std2wxIdentifier(s, converter);
         }
 
-        bool hasDescription = !st1->IsNull(9);
+        bool hasDescription = !st1->isNull(8);
 
         ParameterPtr par = findParameter(param_name);
         if (!par)
@@ -223,13 +220,12 @@ wxString Procedure::getOwner()
     MetadataLoader* loader = db->getMetadataLoader();
     MetadataLoaderTransaction tr(loader);
 
-    IBPP::Statement st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select rdb$owner_name from rdb$procedures where rdb$procedure_name = ?");
-    st1->Set(1, wx2std(getName_(), db->getCharsetConverter()));
-    st1->Execute();
-    st1->Fetch();
-    std::string name;
-    st1->Get(1, name);
+    st1->setString(0, wx2std(getName_(), db->getCharsetConverter()));
+    st1->execute();
+    st1->fetch();
+    std::string name = st1->getString(0);
     return std2wxIdentifier(name, db->getCharsetConverter());
 }
 
@@ -247,25 +243,23 @@ wxString Procedure::getSource()
 	sql += "from rdb$procedures where rdb$procedure_name = ?";
 	if (db->getInfo().getODSVersionIsHigherOrEqualTo(12, 0))
 		sql += " and rdb$package_name is null ";
-	IBPP::Statement st1 = loader->getStatement( sql );
-	st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
-    st1->Fetch();
+	fr::IStatementPtr& st1 = loader->getStatement( sql );
+	st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
+    st1->fetch();
     wxString source;
-	if (!st1->IsNull(2))
+	if (!st1->isNull(1))
 	{
-		std::string s;
-		st1->Get(2, s);
+		std::string s = st1->getString(1);
 		source += "EXTERNAL NAME '"+std2wxIdentifier(s, converter)+ "' \n";
-        if (!st1->IsNull(3))
+        if (!st1->isNull(2))
         {
-            s.clear();
-            st1->Get(3, s);
+            s = st1->getString(2);
             source += "ENGINE " + std2wxIdentifier(s, converter) + "\n";
-            if (!st1->IsNull(1))
+            if (!st1->isNull(0))
             {
                 wxString source1;
-                readBlob(st1, 1, source1, converter);
+                readBlob(st1, 0, source1, converter);
                 source1.Trim();
                 source += source1 + "\n";
             }
@@ -274,7 +268,7 @@ wxString Procedure::getSource()
 	else
 	{
 		wxString source1;
-		readBlob(st1, 1, source1, converter);
+		readBlob(st1, 0, source1, converter);
 		source1.Trim();
 		source += source1 + "\n";
 	}
@@ -336,14 +330,13 @@ wxString Procedure::getSqlSecurity()
         std::string sql(
             "select rdb$sql_security from rdb$procedures where rdb$procedure_name = ?"
             " and rdb$package_name is null ");
-        IBPP::Statement st1 = loader->getStatement(sql);
-        st1->Set(1, wx2std(getName_(), converter));
-        st1->Execute();
-        st1->Fetch();
-        if (st1->IsNull(1))
+        fr::IStatementPtr& st1 = loader->getStatement(sql);
+        st1->setString(0, wx2std(getName_(), converter));
+        st1->execute();
+        st1->fetch();
+        if (st1->isNull(0))
             return wxString();
-        bool b;
-        st1->Get(1, b);
+        bool b = st1->getBool(0);
         return wxString(b ? "SQL SECURITY DEFINER" : "SQL SECURITY INVOKER");
     }
     else
@@ -522,30 +515,29 @@ std::vector<Privilege>* Procedure::getPrivileges(bool splitPerGrantor)
 
     privilegesM.clear();
 
-    IBPP::Statement st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select RDB$USER, RDB$USER_TYPE, RDB$GRANTOR, RDB$PRIVILEGE, "
         "RDB$GRANT_OPTION, RDB$FIELD_NAME "
         "from RDB$USER_PRIVILEGES "
         "where RDB$RELATION_NAME = ? and rdb$object_type = 5 "
         "order by rdb$user, rdb$user_type, rdb$grantor, rdb$privilege"
     );
-    st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
+    st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
     std::string lastuser;
     std::string lastGrantor;
     int lasttype = -1;
     Privilege *pr = 0;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        std::string user, grantor, privilege, field;
-        int usertype, grantoption = 0;
-        st1->Get(1, user);
-        st1->Get(2, usertype);
-        st1->Get(3, grantor);
-        st1->Get(4, privilege);
-        if (!st1->IsNull(5))
-            st1->Get(5, grantoption);
-        st1->Get(6, field);
+        std::string user = st1->getString(0);
+        int usertype = st1->getInt32(1);
+        std::string grantor = st1->getString(2);
+        std::string privilege = st1->getString(3);
+        int grantoption = 0;
+        if (!st1->isNull(4))
+            grantoption = st1->getInt32(4);
+        std::string field = st1->getString(5);
         if (!pr || user != lastuser || usertype != lasttype || (splitPerGrantor && grantor != lastGrantor))
         {
             Privilege p(this, std2wxIdentifier(user, converter),
@@ -609,4 +601,3 @@ const wxString Procedures::getTypeName() const
 {
     return "PROCEDURE_COLLECTION";
 }
-

--- a/src/metadata/relation.cpp
+++ b/src/metadata/relation.cpp
@@ -124,40 +124,37 @@ void Relation::loadProperties()
     sql += db->getInfo().getODSVersionIsHigherOrEqualTo(13, 0)? ", rdb$sql_security " : ", null ";
     sql += "from rdb$relations where rdb$relation_name = ?";
 
-    IBPP::Statement& st1 = loader->getStatement(sql);
-    st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
-    if (st1->Fetch())
+    fr::IStatementPtr& st1 = loader->getStatement(sql);
+    st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
+    if (st1->fetch())
     {
-        std::string name;
-        st1->Get(1, name);
+        std::string name = st1->getString(0);
         ownerM = std2wxIdentifier(name, converter);
-        st1->Get(2, relationTypeM);
+        relationTypeM = st1->getInt32(1);
 
         wxString value;
         // for tables: path to external file
-        if (!st1->IsNull(3))
+        if (!st1->isNull(2))
         {
-            std::string s;
-            st1->Get(3, s);
+            std::string s = st1->getString(2);
             setExternalFilePath(wxString(s.c_str(), *converter));
         }
         else
             setExternalFilePath(wxEmptyString);
 
         // for views: source
-        if (!st1->IsNull(4))
+        if (!st1->isNull(3))
         {
-            readBlob(st1, 4, value, converter);
+            value = wxString(st1->getString(3).c_str(), *converter);
             setSource(value);
         }
         else
             setSource(wxEmptyString);
         // Sql Security
-        if (!st1->IsNull(5))
+        if (!st1->isNull(4))
         {
-            bool b;
-            st1->Get(5, b);
+            bool b = st1->getBool(4);
             sqlSecurityM = wxString(b ? "SQL SECURITY DEFINER" : "SQL SECURITY INVOKER");
 
         }
@@ -228,44 +225,43 @@ void Relation::loadChildren()
     sql +=  " where r.rdb$relation_name = ?"
             " order by r.rdb$field_position";
     
-    IBPP::Statement& st1 = loader->getStatement(sql);
-    st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
+    fr::IStatementPtr& st1 = loader->getStatement(sql);
+    st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
 
     ColumnPtrs columns;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        std::string s, coll;
-        st1->Get(1, s);
+        std::string s = st1->getString(0);
         wxString fname(std2wxIdentifier(s, converter));
         bool notNull = false;
-        if (!st1->IsNull(2))
-            st1->Get(2, &notNull);
-        st1->Get(3, s);
+        if (!st1->isNull(1))
+            notNull = st1->getBool(1);
+        s = st1->getString(2);
         wxString source(std2wxIdentifier(s, converter));
-        if (!st1->IsNull(4))
-            st1->Get(4, coll);
-        wxString collation(std2wxIdentifier(coll, converter));
-        wxString computedSrc, defaultSrc;
-        readBlob(st1, 5, computedSrc, converter);
-        bool hasDefault = !st1->IsNull(6);
+        wxString collation;
+        if (!st1->isNull(3))
+            collation = std2wxIdentifier(st1->getString(3), converter);
+        
+        wxString computedSrc = wxString(st1->getString(4).c_str(), *converter);
+        bool hasDefault = !st1->isNull(5);
+        wxString defaultSrc;
         if (hasDefault)
         {
-            readBlob(st1, 6, defaultSrc, converter);
+            defaultSrc = wxString(st1->getString(5).c_str(), *converter);
             // Some users reported two spaces before DEFAULT word in source
             // Perhaps some other tools can put garbage here? Should we
             // parse it as SQL to clean up comments, whitespace, etc?
             defaultSrc.Trim(false).Remove(0, 8);
         }
-        bool hasDescription = !st1->IsNull(7);
+        bool hasDescription = !st1->isNull(6);
         wxString identityType = "";
         int initialValue = 0, incrementValue = 0;
-        if (!st1->IsNull(8)) {
-            int i;
-            st1->Get(9, i);
+        if (!st1->isNull(7)) {
+            int i = st1->getInt32(8);
             identityType = i == IDENT_TYPE_BY_DEFAULT ? "BY DEFAULT" : i == IDENT_TYPE_ALWAYS ? "ALWAYS" : "";
-            st1->Get(10, initialValue);
-            st1->Get(11, incrementValue);
+            initialValue = st1->getInt32(9);
+            incrementValue = st1->getInt32(10);
         }
 
 
@@ -321,7 +317,7 @@ void Relation::getDependentChecks(std::vector<CheckConstraint>& checks)
     SubjectLocker lock(this);
     wxMBConv* converter = db->getCharsetConverter();
 
-    IBPP::Statement& st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select c.rdb$constraint_name, t.rdb$relation_name, "
         "   t.rdb$trigger_source "
         "from rdb$check_constraints c "
@@ -333,18 +329,16 @@ void Relation::getDependentChecks(std::vector<CheckConstraint>& checks)
         "and t.rdb$trigger_type = 1 and d.rdb$field_name is null "
     );
 
-    st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
-    while (st1->Fetch())
+    st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
+    while (st1->fetch())
     {
-        std::string s;
-        st1->Get(1, s);
+        std::string s = st1->getString(0);
         wxString cname(std2wxIdentifier(s, converter));
-        st1->Get(2, s);
+        s = st1->getString(1);
         wxString table(std2wxIdentifier(s, converter));
 
-        wxString source;
-        readBlob(st1, 3, source, converter);
+        wxString source = wxString(st1->getString(2).c_str(), *converter);
 
         Table* tab = dynamic_cast<Table*>(db->findByNameAndType(ntTable,
             table));
@@ -715,30 +709,29 @@ std::vector<Privilege>* Relation::getPrivileges(bool splitPerGrantor)
     SubjectLocker lock(this);
     wxMBConv* converter = db->getCharsetConverter();
 
-    IBPP::Statement& st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select RDB$USER, RDB$USER_TYPE, RDB$GRANTOR, RDB$PRIVILEGE, "
         "RDB$GRANT_OPTION, RDB$FIELD_NAME "
         "from RDB$USER_PRIVILEGES "
         "where RDB$RELATION_NAME = ? and rdb$object_type = 0 "
         "order by rdb$user, rdb$user_type, rdb$grantor, rdb$grant_option, rdb$privilege"
     );
-    st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
+    st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
     std::string lastuser;
     std::string lastGrantor;
     int lasttype = -1;
     Privilege *pr = 0;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        std::string user, grantor, privilege, field;
-        int usertype, grantoption = 0;
-        st1->Get(1, user);
-        st1->Get(2, usertype);
-        st1->Get(3, grantor);
-        st1->Get(4, privilege);
-        if (!st1->IsNull(5))
-            st1->Get(5, grantoption);
-        st1->Get(6, field);
+        std::string user = st1->getString(0);
+        int usertype = st1->getInt32(1);
+        std::string grantor = st1->getString(2);
+        std::string privilege = st1->getString(3);
+        int grantoption = 0;
+        if (!st1->isNull(4))
+            grantoption = st1->getInt32(4);
+        std::string field = st1->getString(5);
         if (!pr || user != lastuser || usertype != lasttype || (splitPerGrantor && grantor != lastGrantor))
         {
             Privilege p(this, wxString(user.c_str(), *converter).Strip(), usertype);
@@ -764,17 +757,16 @@ void Relation::getTriggers(std::vector<Trigger *>& list,
     MetadataLoaderTransaction tr(loader);
     wxMBConv* converter = db->getCharsetConverter();
 
-    IBPP::Statement& st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select rdb$trigger_name from rdb$triggers"
         " where rdb$relation_name = ?"
         " order by rdb$trigger_sequence"
     );
-    st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
-    while (st1->Fetch())
+    st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
+    while (st1->fetch())
     {
-        std::string name;
-        st1->Get(1, name);
+        std::string name = st1->getString(0);
         Trigger* t = dynamic_cast<Trigger*>(db->findByNameAndType(ntDMLTrigger,
             std2wxIdentifier(name, converter)));
         if (t && t->getFiringTime() == time)

--- a/src/metadata/role.cpp
+++ b/src/metadata/role.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2004-2022 The FlameRobin Development Team
+  Copyright (c) 2004-2026 The FlameRobin Development Team
 
   Permission is hereby granted, free of charge, to any person obtaining
   a copy of this software and associated documentation files (the
@@ -30,8 +30,6 @@
     #include "wx/wx.h"
 #endif
 
-#include <ibpp.h>
-
 #include "core/FRError.h"
 #include "core/StringUtils.h"
 #include "engine/MetadataLoader.h"
@@ -59,29 +57,28 @@ std::vector<Privilege>* Role::getPrivileges(bool splitPerGrantor)
 
     privilegesM.clear();
 
-    IBPP::Statement st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select RDB$USER, RDB$USER_TYPE, RDB$GRANTOR, RDB$PRIVILEGE, "
         "RDB$GRANT_OPTION "
         "from RDB$USER_PRIVILEGES "
         "where RDB$RELATION_NAME = ? and rdb$object_type = 13 "
         "order by rdb$user, rdb$user_type, rdb$grantor, rdb$grant_option, rdb$privilege"
     );
-    st1->Set(1, wx2std(getName_(), db->getCharsetConverter()));
-    st1->Execute();
+    st1->setString(0, wx2std(getName_(), db->getCharsetConverter()));
+    st1->execute();
     std::string lastuser;
     std::string lastGrantor;
     int lasttype = -1;
     Privilege *pr = 0;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        std::string user, grantor, privilege;
-        int usertype, grantoption = 0;
-        st1->Get(1, user);
-        st1->Get(2, usertype);
-        st1->Get(3, grantor);
-        st1->Get(4, privilege);
-        if (!st1->IsNull(5))
-            st1->Get(5, grantoption);
+        std::string user = st1->getString(0);
+        int usertype = st1->getInt32(1);
+        std::string grantor = st1->getString(2);
+        std::string privilege = st1->getString(3);
+        int grantoption = 0;
+        if (!st1->isNull(4))
+            grantoption = st1->getInt32(4);
         if (!pr || user != lastuser || usertype != lasttype || (splitPerGrantor && grantor != lastGrantor))
         {
             Privilege p(this, wxString(user).Strip(), usertype);
@@ -103,13 +100,12 @@ wxString Role::getOwner()
     MetadataLoader* loader = db->getMetadataLoader();
     MetadataLoaderTransaction tr(loader);
 
-    IBPP::Statement st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select rdb$owner_name from rdb$roles where rdb$role_name = ?");
-    st1->Set(1, wx2std(getName_(), db->getCharsetConverter()));
-    st1->Execute();
-    st1->Fetch();
-    std::string name;
-    st1->Get(1, name);
+    st1->setString(0, wx2std(getName_(), db->getCharsetConverter()));
+    st1->execute();
+    st1->fetch();
+    std::string name = st1->getString(0);
     return wxString(name).Trim();
 }
 
@@ -190,4 +186,3 @@ const wxString Roles::getTypeName() const
 {
     return "ROLE_COLLECTION";
 }
-

--- a/src/metadata/table.cpp
+++ b/src/metadata/table.cpp
@@ -113,7 +113,7 @@ void Table::loadCheckConstraints()
     MetadataLoaderTransaction tr(loader);
     SubjectLocker lock(this);
 
-    IBPP::Statement& st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select r.rdb$constraint_name, t.rdb$trigger_source, d.rdb$field_name "
         " from rdb$relation_constraints r "
         " join rdb$check_constraints c on r.rdb$constraint_name=c.rdb$constraint_name and r.rdb$constraint_type = 'CHECK'"
@@ -125,18 +125,16 @@ void Table::loadCheckConstraints()
         " order by 1 "
     );
 
-    st1->Set(1, wx2std(getName_(), conv));
-    st1->Execute();
+    st1->setString(0, wx2std(getName_(), conv));
+    st1->execute();
     CheckConstraint *cc = 0;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        std::string s;
-        st1->Get(1, s);
+        std::string s = st1->getString(0);
         wxString cname(std2wxIdentifier(s, conv));
         if (!cc || cname != cc->getName_()) // new constraint
         {
-            wxString source;
-            readBlob(st1, 2, source, conv);
+            wxString source = wxString(st1->getString(1).c_str(), *conv);
 
             CheckConstraint c;
             c.setParent(this);
@@ -146,9 +144,9 @@ void Table::loadCheckConstraints()
             cc = &checkConstraintsM.back();
         }
 
-        if (!st1->IsNull(3))
+        if (!st1->isNull(2))
         {
-            st1->Get(3, s);
+            s = st1->getString(2);
             wxString fname(std2wxIdentifier(s, conv));
             cc->columnsM.push_back(fname);
         }
@@ -173,23 +171,22 @@ void Table::loadPrimaryKey()
     MetadataLoaderTransaction tr(loader);
     SubjectLocker lock(this);
 
-    IBPP::Statement& st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select r.rdb$constraint_name, i.rdb$field_name, r.rdb$index_name "
         "from rdb$relation_constraints r, rdb$index_segments i "
         "where r.rdb$relation_name=? and r.rdb$index_name=i.rdb$index_name and "
         "(r.rdb$constraint_type='PRIMARY KEY') order by r.rdb$constraint_name, i.rdb$field_position"
     );
 
-    st1->Set(1, wx2std(getName_(), conv));
-    st1->Execute();
-    while (st1->Fetch())
+    st1->setString(0, wx2std(getName_(), conv));
+    st1->execute();
+    while (st1->fetch())
     {
-        std::string s;
-        st1->Get(1, s);
+        std::string s = st1->getString(0);
         wxString cname(std2wxIdentifier(s, conv));
-        st1->Get(2, s);
+        s = st1->getString(1);
         wxString fname(std2wxIdentifier(s, conv));
-        st1->Get(3, s);
+        s = st1->getString(2);
         wxString ixname(std2wxIdentifier(s, conv));
 
         primaryKeyM.setName_(cname);
@@ -217,24 +214,23 @@ void Table::loadUniqueConstraints()
     MetadataLoaderTransaction tr(loader);
     SubjectLocker lock(this);
 
-    IBPP::Statement& st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select r.rdb$constraint_name, i.rdb$field_name, r.rdb$index_name "
         "from rdb$relation_constraints r, rdb$index_segments i "
         "where r.rdb$relation_name=? and r.rdb$index_name=i.rdb$index_name and "
         "(r.rdb$constraint_type='UNIQUE') order by r.rdb$constraint_name, i.rdb$field_position"
     );
 
-    st1->Set(1, wx2std(getName_(), conv));
-    st1->Execute();
+    st1->setString(0, wx2std(getName_(), conv));
+    st1->execute();
     UniqueConstraint *cc = 0;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        std::string s;
-        st1->Get(1, s);
+        std::string s = st1->getString(0);
         wxString cname(std2wxIdentifier(s, conv));
-        st1->Get(2, s);
+        s = st1->getString(1);
         wxString fname(std2wxIdentifier(s, conv));
-        st1->Get(3, s);
+        s = st1->getString(2);
         wxString ixname(std2wxIdentifier(s, conv));
 
         if (cc && cc->getName_() == cname)
@@ -302,7 +298,7 @@ void Table::loadForeignKeys()
     MetadataLoaderTransaction tr(loader);
     SubjectLocker lock(this);
 
-    IBPP::Statement& st1 = loader->getStatement(
+    fr::IStatementPtr& st1 = loader->getStatement(
         "select r.rdb$constraint_name, i.rdb$field_name, c.rdb$update_rule, "
         " c.rdb$delete_rule, c.RDB$CONST_NAME_UQ, r.rdb$index_name "
         "from rdb$relation_constraints r, rdb$index_segments i, rdb$ref_constraints c "
@@ -311,7 +307,7 @@ void Table::loadForeignKeys()
         "and (r.rdb$constraint_type='FOREIGN KEY') order by 1, i.rdb$field_position"
     );
 
-    IBPP::Statement& st2 = loader->getStatement(
+    fr::IStatementPtr& st2 = loader->getStatement(
         "select r.rdb$relation_name, i.rdb$field_name"
         " from rdb$relation_constraints r"
         " join rdb$index_segments i on i.rdb$index_name = r.rdb$index_name "
@@ -319,23 +315,21 @@ void Table::loadForeignKeys()
         " order by i.rdb$field_position "
     );
 
-    st1->Set(1, wx2std(getName_(), conv));
-    st1->Execute();
+    st1->setString(0, wx2std(getName_(), conv));
+    st1->execute();
     ForeignKey *fkp = 0;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        std::string s;
-        st1->Get(1, s);
+        std::string s = st1->getString(0);
         wxString cname(std2wxIdentifier(s, conv));
-        st1->Get(2, s);
+        s = st1->getString(1);
         wxString fname(std2wxIdentifier(s, conv));
-        st1->Get(3, s);
+        s = st1->getString(2);
         wxString update_rule(std2wxIdentifier(s, conv));
-        st1->Get(4, s);
+        s = st1->getString(3);
         wxString delete_rule(std2wxIdentifier(s, conv));
-        std::string ref_constraint;
-        st1->Get(5, ref_constraint);
-        st1->Get(6, s);
+        std::string ref_constraint = st1->getString(4);
+        s = st1->getString(5);
         wxString ixname(std2wxIdentifier(s, conv));
 
         if (fkp && fkp->getName_() == cname) // add column
@@ -351,13 +345,13 @@ void Table::loadForeignKeys()
             fkp->deleteActionM = delete_rule;
             fkp->indexNameM = ixname;
 
-            st2->Set(1, ref_constraint);
-            st2->Execute();
+            st2->setString(0, ref_constraint);
+            st2->execute();
             std::string rtable;
-            while (st2->Fetch())
+            while (st2->fetch())
             {
-                st2->Get(1, rtable);
-                st2->Get(2, s);
+                rtable = st2->getString(0);
+                s = st2->getString(1);
                 fkp->referencedColumnsM.push_back(std2wxIdentifier(s, conv));
             }
             fkp->referencedTableM = std2wxIdentifier(rtable, conv);
@@ -398,42 +392,39 @@ void Table::loadIndices()
         " where i.rdb$relation_name = ? "
         " order by i.rdb$index_name, s.rdb$field_position ";
 
-    IBPP::Statement& st1 = loader->getStatement(sql);
+    fr::IStatementPtr& st1 = loader->getStatement(sql);
 
-    st1->Set(1, wx2std(getName_(), conv));
-    st1->Execute();
+    st1->setString(0, wx2std(getName_(), conv));
+    st1->execute();
     Index* i = 0;
-    while (st1->Fetch())
+    while (st1->fetch())
     {
-        std::string s;
-        st1->Get(1, s);
+        std::string s = st1->getString(0);
         wxString ixname(std2wxIdentifier(s, conv));
 
         short unq, inactive, type;
-        if (st1->IsNull(2))     // null = non-unique
+        if (st1->isNull(1))     // null = non-unique
             unq = 0;
         else
-            st1->Get(2, unq);
-        if (st1->IsNull(3))     // null = active
+            unq = (short)st1->getInt32(1);
+        if (st1->isNull(2))     // null = active
             inactive = 0;
         else
-            st1->Get(3, inactive);
-        if (st1->IsNull(4))     // null = ascending
+            inactive = (short)st1->getInt32(2);
+        if (st1->isNull(3))     // null = ascending
             type = 0;
         else
-            st1->Get(4, type);
+            type = (short)st1->getInt32(3);
         double statistics;
-        if (st1->IsNull(5))     // this can happen, see bug #1825725
+        if (st1->isNull(4))     // this can happen, see bug #1825725
             statistics = -1;
         else
-            st1->Get(5, statistics);
+            statistics = st1->getDouble(4);
 
-        st1->Get(6, s);
+        s = st1->getString(5);
         wxString fname(std2wxIdentifier(s, conv));
-        wxString expression;
-        readBlob(st1, 8, expression, conv);
-        wxString condition;
-        readBlob(st1, 9, condition, conv);
+        wxString expression = wxString(st1->getString(7).c_str(), *conv);
+        wxString condition = wxString(st1->getString(8).c_str(), *conv);
 
         if (i && i->getName_() == ixname)
             i->getSegments()->push_back(fname);
@@ -444,7 +435,7 @@ void Table::loadIndices()
                 inactive == 0,
                 type == 0,
                 statistics,
-                !st1->IsNull(7),
+                !st1->isNull(6),
                 expression,
                 condition
             );

--- a/src/metadata/trigger.cpp
+++ b/src/metadata/trigger.cpp
@@ -235,52 +235,47 @@ void Trigger::loadProperties()
 
     sql += "from rdb$triggers t where rdb$trigger_name = ? ";
 
-    IBPP::Statement& st1 = loader->getStatement(sql);
+    fr::IStatementPtr& st1 = loader->getStatement(sql);
 
-    st1->Set(1, wx2std(getName_(), converter));
-    st1->Execute();
-    if (st1->Fetch())
+    st1->setString(0, wx2std(getName_(), converter));
+    st1->execute();
+    if (st1->fetch())
     {
-        if (st1->IsNull(1))
+        if (st1->isNull(0))
             relationNameM.clear();
         else
         {
-            std::string objname;
-            st1->Get(1, objname);
+            std::string objname = st1->getString(0);
             relationNameM = std2wxIdentifier(objname, converter);
         }
-        st1->Get(2, &positionM);
+        positionM = st1->getInt32(1);
 
         short temp;
-        if (st1->IsNull(3))
+        if (st1->isNull(2))
             temp = 0;
         else
-            st1->Get(3, &temp);
+            temp = (short)st1->getInt32(2);
         activeM = (temp == 0);
 
-        st1->Get(4, &typeM);
-        st1->Get(4, typeM);
+        typeM = st1->getInt32(3);
 
 
-        if (!st1->IsNull(8))
+        if (!st1->isNull(7))
         {
-            bool b;
-            st1->Get(8, b);
+            bool b = st1->getBool(7);
             sqlSecurityM = b ? "SQL SECURITY DEFINER" : "SQL SECURITY INVOKER";
         }
         else
             sqlSecurityM.clear();
 
-		if (!st1->IsNull(6))
+		if (!st1->isNull(5))
 		{
-			std::string s;
-			st1->Get(6, s);
+			std::string s = st1->getString(5);
 			sourceM += "EXTERNAL NAME '" + std2wxIdentifier(s, converter) + "'\n";
 			entryPointM = std2wxIdentifier(s, converter);
-            if (!st1->IsNull(7))
+            if (!st1->isNull(6))
             {
-                //std::string s;
-                st1->Get(7, s);
+                s = st1->getString(6);
                 sourceM += "ENGINE " + std2wxIdentifier(s, converter) + "\n";
                 engineNameM = std2wxIdentifier(s, converter);
             }
@@ -292,10 +287,10 @@ void Trigger::loadProperties()
             entryPointM.clear();
             engineNameM.clear();
         }
-        if (!st1->IsNull(5))
+        if (!st1->isNull(4))
         {
             wxString source1;
-            readBlob(st1, 5, source1, converter);
+            readBlob(st1, 4, source1, converter);
             source1.Trim(false);     // remove leading whitespace
             sourceM += "\n" + source1 + "\n";
         }


### PR DESCRIPTION
This PR implements Phase 2, Step 1 of the fb-cpp migration: "Systematic refactoring of MetadataItem classes to use DAL interfaces".

### Key Changes:
- **Core Abstraction Layer Enhancements**:
    - Added `getDALDatabase()` to `MetadataItem` base class for easy access to the abstraction layer.
    - Added `getSql()` to `fr::IStatement` interface to support statement caching and tracking.
    - Updated `IbppStatement` and `FbCppStatement` to implement the new interface methods.
    - **Robust Blob Handling**: Fixed `IbppStatement::getString` to correctly handle Firebird Blobs by reading them in chunks, ensuring transparent access via the DAL.
- **Refactored `MetadataLoader`**:
    - Fully migrated `MetadataLoader` to use `fr::IDatabasePtr`, `fr::ITransactionPtr`, and `fr::IStatementPtr`.
    - This allows all metadata loading logic to benefit from the DAL, facilitating the switch between IBPP and fb-cpp backends.
- **Metadata Class Migrations**:
    - Refactored `Relation` (Table/View base class) to use DAL for loading properties, columns, dependent checks, privileges, and triggers.
    - Refactored `Database` to use DAL for identifier loading, database info, timezone loading, and collation discovery.
    - Refactored `LoadDescriptionVisitor` and `SaveDescriptionVisitor` to handle object descriptions via the DAL.

These changes significantly decouple the metadata management logic from the legacy IBPP library and provide a clean, interface-driven approach for all future metadata operations.

Closes #555