### PR TITLE
Phase 3: Port SQL execution engine and UI components to DAL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,10 +125,12 @@ list(APPEND SOURCE_LIST
         ${SOURCEDIR}/engine/db/ibpp/IbppTransaction.cpp
         ${SOURCEDIR}/engine/db/ibpp/IbppStatement.cpp
         ${SOURCEDIR}/engine/db/ibpp/IbppService.cpp
+        ${SOURCEDIR}/engine/db/ibpp/IbppBlob.cpp
         ${SOURCEDIR}/engine/db/fbcpp/FbCppDatabase.cpp
         ${SOURCEDIR}/engine/db/fbcpp/FbCppTransaction.cpp
         ${SOURCEDIR}/engine/db/fbcpp/FbCppStatement.cpp
         ${SOURCEDIR}/engine/db/fbcpp/FbCppService.cpp
+        ${SOURCEDIR}/engine/db/fbcpp/FbCppBlob.cpp
         ${SOURCEDIR}/core/ArtProvider.cpp
         ${SOURCEDIR}/core/CodeTemplateProcessor.cpp
         ${SOURCEDIR}/core/FRDecimal.cpp
@@ -737,10 +739,12 @@ add_executable(dal_types_test
     ${SOURCEDIR}/engine/db/ibpp/IbppTransaction.cpp
     ${SOURCEDIR}/engine/db/ibpp/IbppStatement.cpp
     ${SOURCEDIR}/engine/db/ibpp/IbppService.cpp
+    ${SOURCEDIR}/engine/db/ibpp/IbppBlob.cpp
     ${SOURCEDIR}/engine/db/fbcpp/FbCppDatabase.cpp
     ${SOURCEDIR}/engine/db/fbcpp/FbCppTransaction.cpp
     ${SOURCEDIR}/engine/db/fbcpp/FbCppStatement.cpp
     ${SOURCEDIR}/engine/db/fbcpp/FbCppService.cpp
+    ${SOURCEDIR}/engine/db/fbcpp/FbCppBlob.cpp
     ${SOURCEDIR}/core/FRError.cpp
     ${SOURCEDIR}/core/FRInt128.cpp
     ${SOURCEDIR}/core/FRDecimal.cpp

--- a/src/core/StringUtils.cpp
+++ b/src/core/StringUtils.cpp
@@ -312,3 +312,37 @@ wxString IBPPtype2string(Database* db, IBPP::SDT t, int subtype, int size,
     }
 }
 
+wxString DALtype2string(Database* db, fr::ColumnType t, int subtype, int size,
+    int scale)
+{
+    if (scale > 0)
+        return wxString::Format("NUMERIC(%d,%d)", size == 4 ? 9 : 18, scale);
+
+    switch (t)
+    {
+    case fr::ColumnType::Varchar:
+    case fr::ColumnType::Char:
+    {
+        int bpc = db->getCharsetById(subtype)->getBytesPerChar();
+        if (subtype == 1) // charset OCTETS
+            return wxString::Format("OCTETS(%d)", bpc ? size / bpc : size);
+        return wxString::Format("STRING(%d)", bpc ? size / bpc : size);
+    }
+    case fr::ColumnType::Blob:      return wxString::Format("BLOB SUB_TYPE %d", subtype);
+    case fr::ColumnType::Date:      return "DATE";
+    case fr::ColumnType::Time:      return "TIME";
+    case fr::ColumnType::Timestamp: return "TIMESTAMP";
+    case fr::ColumnType::Integer:   return "INTEGER";
+    case fr::ColumnType::BigInt:    return "BIGINT";
+    case fr::ColumnType::Float:     return "FLOAT";
+    case fr::ColumnType::Double:    return "DOUBLE PRECISION";
+    case fr::ColumnType::Boolean:   return "BOOLEAN";
+    case fr::ColumnType::TimeTz:    return "TIME WITH TIMEZONE";
+    case fr::ColumnType::TimestampTz: return "TIMESTAMP WITH TIMEZONE";
+    case fr::ColumnType::Int128:    return "INT128";
+    case fr::ColumnType::Decfloat16:     return "DECFLOAT(16)";
+    case fr::ColumnType::Decfloat34:     return "DECFLOAT(34)";
+    default:                return "UNKNOWN";
+    }
+}
+

--- a/src/core/StringUtils.h
+++ b/src/core/StringUtils.h
@@ -63,6 +63,9 @@ wxString loadEntireFile(const wxFileName& filename);
 wxString wrapText(const wxString& text, size_t maxWidth, size_t indent);
 
 
+#include "engine/db/DatabaseBackend.h"
+
 wxString IBPPtype2string(Database* db, IBPP::SDT t, int subtype, int size, int scale);
+wxString DALtype2string(Database* db, fr::ColumnType t, int subtype, int size, int scale);
 
 #endif // FR_STRINGUTILS_H

--- a/src/engine/db/DalTypesTest.cpp
+++ b/src/engine/db/DalTypesTest.cpp
@@ -32,6 +32,7 @@
 #include "engine/db/IDatabase.h"
 #include "engine/db/ITransaction.h"
 #include "engine/db/IStatement.h"
+#include "engine/db/IBlob.h"
 #include "core/StringUtils.h"
 
 // Minimal wx2std implementation for tests to avoid linking StringUtils.cpp
@@ -184,6 +185,130 @@ bool runTestsForBackend(fr::DatabaseBackend backend, const std::string& /*server
         ok = check(info.ods > 0, "getInfo ODS") && ok;
         ok = check(info.pageSize > 0, "getInfo PageSize") && ok;
         ok = check(info.nextTransaction > 0, "getInfo NextTransaction") && ok;
+
+        // Statistics and Counts
+        std::cout << "  Testing statistics and counts...\n";
+        int fetch, mark, read, write, mem;
+        db->getStatistics(&fetch, &mark, &read, &write, &mem);
+        ok = check(fetch >= 0, "getStatistics") && ok;
+
+        int ins, upd, del, ridx, rseq;
+        db->getCounts(&ins, &upd, &del, &ridx, &rseq);
+        ok = check(ridx >= 0, "getCounts") && ok;
+
+        std::map<int, fr::CountInfo> detailedCounts;
+        db->getDetailedCounts(detailedCounts);
+        ok = check(detailedCounts.size() >= 0, "getDetailedCounts") && ok;
+
+        // Statement Type and Plan
+        std::cout << "  Testing statement type and plan...\n";
+        st->prepare("SELECT * FROM RDB$DATABASE");
+        ok = check(st->getType() == fr::StatementType::Select, "getType Select") && ok;
+        std::string plan = st->getPlan();
+        ok = check(!plan.empty(), "getPlan") && ok;
+
+        // Create a dummy table for testing UPDATE and affected rows
+        try {
+            st->prepare("DROP TABLE DAL_TEST");
+            st->execute();
+            tr->commitRetain();
+        } catch (...) {}
+
+        st->prepare("CREATE TABLE DAL_TEST (ID INTEGER)");
+        st->execute();
+        tr->commitRetain();
+
+        st->prepare("INSERT INTO DAL_TEST (ID) VALUES (1)");
+        st->execute();
+
+        st->prepare("UPDATE DAL_TEST SET ID = 2 WHERE ID = 1");
+        ok = check(st->getType() == fr::StatementType::Update, "getType Update") && ok;
+
+        // Affected rows
+        st->execute();
+        ok = check(st->getAffectedRows() == 1, "getAffectedRows") && ok;
+
+        // Parameter tests
+        std::cout << "  Testing statement parameters...\n";
+        st->prepare("UPDATE DAL_TEST SET ID = ? WHERE ID = ?");
+        ok = check(st->getParameterCount() == 2, "getParameterCount") && ok;
+        ok = check(st->getParameterType(0) == fr::ColumnType::Integer, "getParameterType 0") && ok;
+        ok = check(st->getParameterType(1) == fr::ColumnType::Integer, "getParameterType 1") && ok;
+
+        // Named parameter simulation (IBPP supports it)
+        if (backend == fr::DatabaseBackend::IBPP)
+        {
+            st->prepare("UPDATE DAL_TEST SET ID = :newid WHERE ID = :oldid");
+            ok = check(st->getParameterCount() == 2, "getParameterCount (named)") && ok;
+            ok = checkStr(st->getParameterName(0), "newid", "getParameterName 0") && ok;
+            ok = checkStr(st->getParameterName(1), "oldid", "getParameterName 1") && ok;
+            auto indices = st->findParameterIndicesByName("oldid");
+            ok = check(indices.size() == 1 && indices[0] == 2, "findParameterIndicesByName") && ok;
+        }
+
+        // Typed parameter setting
+        std::cout << "  Testing typed parameter setting...\n";
+        st->prepare("INSERT INTO DAL_TEST (ID) VALUES (?)");
+        st->setInt32(0, 123);
+        st->execute();
+        st->prepare("SELECT ID FROM DAL_TEST WHERE ID = 123");
+        st->execute();
+        ok = check(st->fetch(), "fetch inserted row") && ok;
+        ok = check(st->getInt32(0) == 123, "getInt32 matches setInt32") && ok;
+
+        // Date/Time parameter setting
+        std::cout << "  Testing date/time parameter setting...\n";
+        st->prepare("SELECT CAST(? AS DATE), CAST(? AS TIME), CAST(? AS TIMESTAMP) FROM RDB$DATABASE");
+        st->setDate(0, 2023, 5, 25);
+        st->setTime(1, 14, 30, 45, 0);
+        st->setTimestamp(2, 2023, 5, 25, 14, 30, 45, 0);
+        st->execute();
+        ok = check(st->fetch(), "fetch date/time results") && ok;
+        ok = check(st->getDate(0).find("2023-05-25") != std::string::npos, "setDate result") && ok;
+        ok = check(st->getTime(1).find("14:30:45") != std::string::npos, "setTime result") && ok;
+        ok = check(st->getTimestamp(2).find("2023-05-25 14:30:45") != std::string::npos, "setTimestamp result") && ok;
+
+        // BLOB tests
+        std::cout << "  Testing BLOB operations...\n";
+        try {
+            st->prepare("DROP TABLE BLOB_TEST");
+            st->execute();
+            tr->commitRetain();
+        } catch (...) {}
+        st->prepare("CREATE TABLE BLOB_TEST (ID INTEGER, B BLOB SUB_TYPE TEXT)");
+        st->execute();
+        tr->commitRetain();
+
+        st->prepare("INSERT INTO BLOB_TEST (ID, B) VALUES (2, 'Direct SQL blob')");
+        st->execute();
+        tr->commitRetain();
+
+        st->prepare("SELECT B FROM BLOB_TEST WHERE ID = 2");
+        st->execute();
+        ok = check(st->fetch(), "fetch row with blob") && ok;
+        fr::IBlobPtr b = st->getBlob(0);
+        ok = check(b != nullptr, "getBlob not null") && ok;
+        if (b)
+        {
+            b->open();
+            char buf[100];
+            int len = b->read(buf, sizeof(buf)-1);
+            if (len < 0) len = 0;
+            buf[len] = '\0';
+            ok = checkStr(buf, "Direct SQL blob", "read blob content") && ok;
+            b->close();
+        }
+
+        // Transaction configuration
+        std::cout << "  Testing transaction configuration...\n";
+        fr::ITransactionPtr tr2 = db->createTransaction();
+        tr2->setAccessMode(fr::TransactionAccessMode::Read);
+        tr2->setIsolationLevel(fr::TransactionIsolationLevel::ReadCommitted);
+        tr2->setLockResolution(fr::TransactionLockResolution::NoWait);
+        tr2->start();
+        ok = check(tr2->isActive(), "Transaction configuration and start") && ok;
+        tr2->commit();
+
         // Check if Firebird 4.0+ by trying to CAST to DECFLOAT
         std::cout << "  Checking for Firebird 4.0+ types support...\n";
         try 

--- a/src/engine/db/DatabaseBackend.h
+++ b/src/engine/db/DatabaseBackend.h
@@ -27,9 +27,13 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <map>
+#include <array>
 
 namespace fr
 {
+
+typedef std::array<uint8_t, 8> DBKey;
 
 enum class DatabaseBackend
 {
@@ -60,6 +64,22 @@ enum class ColumnType
     TimestampTz
 };
 
+enum class StatementType
+{
+    Unknown,
+    Select,
+    Insert,
+    Update,
+    Delete,
+    DDL,
+    ExecProcedure,
+    StartTransaction,
+    Commit,
+    Rollback,
+    SetGenerator,
+    Savepoint
+};
+
 struct DatabaseInfoData
 {
     int ods;
@@ -78,6 +98,17 @@ struct DatabaseInfoData
     int nextTransaction;
 };
 
+struct CountInfo
+{
+    int inserts;
+    int updates;
+    int deletes;
+    int readIndex;
+    int readSequence;
+
+    CountInfo() : inserts(0), updates(0), deletes(0), readIndex(0), readSequence(0) {}
+};
+
 struct UserData
 {
     std::string username;
@@ -94,11 +125,13 @@ class IDatabase;
 class ITransaction;
 class IStatement;
 class IService;
+class IBlob;
 
 typedef std::shared_ptr<IDatabase> IDatabasePtr;
 typedef std::shared_ptr<ITransaction> ITransactionPtr;
 typedef std::shared_ptr<IStatement> IStatementPtr;
 typedef std::shared_ptr<IService> IServicePtr;
+typedef std::shared_ptr<IBlob> IBlobPtr;
 
 } // namespace fr
 

--- a/src/engine/db/IBlob.h
+++ b/src/engine/db/IBlob.h
@@ -21,44 +21,32 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#ifndef FR_FBCPP_TRANSACTION_H
-#define FR_FBCPP_TRANSACTION_H
+#ifndef FR_IBLOB_H
+#define FR_IBLOB_H
 
-#include "engine/db/ITransaction.h"
-#include <fb-cpp/fb-cpp.h>
-#include <optional>
+#include "engine/db/DatabaseBackend.h"
 
 namespace fr
 {
 
-class FbCppTransaction : public ITransaction
+class IBlob
 {
 public:
-    FbCppTransaction(fbcpp::Attachment& attachment);
-    virtual ~FbCppTransaction() = default;
+    virtual ~IBlob() = default;
 
-    virtual void start() override;
-    virtual void commit() override;
-    virtual void rollback() override;
-    virtual void commitRetain() override;
-    virtual void rollbackRetain() override;
+    virtual void open() = 0;
+    virtual void create() = 0;
+    virtual void close() = 0;
+    virtual void cancel() = 0;
 
-    virtual bool isActive() override;
-
-    virtual void setAccessMode(TransactionAccessMode mode) override;
-    virtual void setIsolationLevel(TransactionIsolationLevel level) override;
-    virtual void setLockResolution(TransactionLockResolution resolution) override;
-
-    fbcpp::Transaction& getFbCppTransaction();
-
-private:
-    fbcpp::Attachment& attachmentM;
-    std::optional<fbcpp::Transaction> transactionM;
-    TransactionAccessMode modeM;
-    TransactionIsolationLevel levelM;
-    TransactionLockResolution resolutionM;
+    virtual int read(void* buffer, int size) = 0;
+    virtual void write(const void* buffer, int size) = 0;
+    
+    virtual long getLength() = 0;
+    virtual int getSegmentCount() = 0;
+    virtual int getMaxSegmentSize() = 0;
 };
 
 } // namespace fr
 
-#endif // FR_FBCPP_TRANSACTION_H
+#endif // FR_IBLOB_H

--- a/src/engine/db/IDatabase.h
+++ b/src/engine/db/IDatabase.h
@@ -25,11 +25,13 @@
 #define FR_IDATABASE_H
 
 #include "engine/db/DatabaseBackend.h"
+#include <memory>
+#include <map>
 
 namespace fr
 {
 
-class IDatabase
+class IDatabase : public std::enable_shared_from_this<IDatabase>
 {
 public:
     virtual ~IDatabase() = default;
@@ -58,6 +60,12 @@ public:
 
     virtual std::string getTimezoneName(int timezoneId) = 0;
     virtual void getInfo(DatabaseInfoData* data) = 0;
+
+    virtual void getStatistics(int* fetch, int* mark, int* read, int* write, int* mem) = 0;
+    virtual void getCounts(int* ins, int* upd, int* del, int* ridx, int* rseq) = 0;
+    virtual void getDetailedCounts(std::map<int, CountInfo>& counts) = 0;
+
+    virtual IBlobPtr createBlob(ITransactionPtr tr) = 0;
 
     virtual DatabaseBackend getBackendType() const = 0;
 };

--- a/src/engine/db/IStatement.h
+++ b/src/engine/db/IStatement.h
@@ -50,14 +50,24 @@ public:
     virtual void setInt64(int index, int64_t value) = 0;
     virtual void setDouble(int index, double value) = 0;
     virtual void setBool(int index, bool value) = 0;
+    virtual void setDate(int index, int year, int month, int day) = 0;
+    virtual void setTime(int index, int hour, int minute, int second, int fraction) = 0;
+    virtual void setTimestamp(int index, int year, int month, int day,
+        int hour, int minute, int second, int fraction) = 0;
+    virtual void setBytes(int index, const void* data, int size) = 0;
 
-    // Result fetching
+    // Result fetching (0-based)
     virtual bool isNull(int index) = 0;
     virtual std::string getString(int index) = 0;
     virtual int32_t getInt32(int index) = 0;
     virtual int64_t getInt64(int index) = 0;
     virtual double getDouble(int index) = 0;
     virtual bool getBool(int index) = 0;
+
+    // Binary and BLOB support
+    virtual void getBytes(int index, void* data, int size) = 0;
+    virtual IBlobPtr getBlob(int index) = 0;
+    virtual void setBlob(int index, IBlobPtr blob) = 0;
 
     // Firebird specific types (as strings for common exchange)
     virtual std::string getDate(int index) = 0;
@@ -74,6 +84,21 @@ public:
     virtual int getColumnSize(int index) = 0;
     virtual std::string getColumnAlias(int index) = 0;
     virtual std::string getColumnTable(int index) = 0;
+
+    virtual std::string getPlan() = 0;
+    virtual StatementType getType() = 0;
+    virtual int getParameterCount() = 0;
+    virtual std::string getParameterName(int index) = 0;
+    virtual std::vector<int> findParameterIndicesByName(const std::string& name) = 0;
+    virtual ColumnType getParameterType(int index) = 0;
+    virtual int getParameterSubtype(int index) = 0;
+    virtual int getParameterScale(int index) = 0;
+    virtual int getParameterSize(int index) = 0;
+
+    virtual int getAffectedRows() = 0;
+
+    virtual IDatabasePtr getDatabase() = 0;
+    virtual ITransactionPtr getTransaction() = 0;
 };
 
 } // namespace fr

--- a/src/engine/db/ITransaction.h
+++ b/src/engine/db/ITransaction.h
@@ -30,7 +30,8 @@ namespace fr
 {
 
 enum class TransactionAccessMode { Read, Write };
-enum class TransactionIsolationLevel { Consistency, Concurrency, ReadCommitted };
+enum class TransactionIsolationLevel { Consistency, Concurrency, ReadCommitted, ReadDirty };
+enum class TransactionLockResolution { Wait, NoWait };
 
 class ITransaction
 {
@@ -47,6 +48,7 @@ public:
 
     virtual void setAccessMode(TransactionAccessMode mode) = 0;
     virtual void setIsolationLevel(TransactionIsolationLevel level) = 0;
+    virtual void setLockResolution(TransactionLockResolution resolution) = 0;
 };
 
 } // namespace fr

--- a/src/engine/db/fbcpp/FbCppBlob.cpp
+++ b/src/engine/db/fbcpp/FbCppBlob.cpp
@@ -1,0 +1,110 @@
+/*
+  Copyright (c) 2004-2026 The FlameRobin Development Team
+
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files (the
+  "Software"), to deal in the Software without restriction, including
+  without limitation the rights to use, copy, modify, merge, publish,
+  distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so, subject to
+  the following conditions:
+
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include "engine/db/fbcpp/FbCppBlob.h"
+#include <stdexcept>
+
+namespace fr
+{
+
+FbCppBlob::FbCppBlob(fbcpp::Attachment& attachment, fbcpp::Transaction& transaction)
+    : attachmentM(attachment), transactionM(transaction)
+{
+}
+
+FbCppBlob::FbCppBlob(fbcpp::Attachment& attachment, fbcpp::Transaction& transaction, const fbcpp::BlobId& blobId)
+    : attachmentM(attachment), transactionM(transaction), blobIdM(blobId)
+{
+}
+
+void FbCppBlob::open()
+{
+    if (blobIdM.isEmpty())
+        throw std::runtime_error("Blob ID is empty");
+    blobM.emplace(attachmentM, transactionM, blobIdM);
+}
+
+void FbCppBlob::create()
+{
+    blobM.emplace(attachmentM, transactionM);
+    blobIdM = blobM->getId();
+}
+
+void FbCppBlob::close()
+{
+    if (blobM)
+    {
+        blobM->close();
+        blobM.reset();
+    }
+}
+
+void FbCppBlob::cancel()
+{
+    if (blobM)
+    {
+        blobM->cancel();
+        blobM.reset();
+    }
+}
+
+int FbCppBlob::read(void* buffer, int size)
+{
+    if (!blobM)
+        throw std::runtime_error("Blob not open");
+    return (int)blobM->read(std::span<char>(static_cast<char*>(buffer), size));
+}
+
+void FbCppBlob::write(const void* buffer, int size)
+{
+    if (!blobM)
+        throw std::runtime_error("Blob not open");
+    blobM->write(std::span<const char>(static_cast<const char*>(buffer), size));
+}
+
+long FbCppBlob::getLength()
+{
+    if (!blobM)
+    {
+        open();
+        long len = (long)blobM->getLength();
+        close();
+        return len;
+    }
+    return (long)blobM->getLength();
+}
+
+int FbCppBlob::getSegmentCount()
+{
+    // fb-cpp doesn't seem to expose segment count directly via the high-level API
+    // We might need to implement it using getInfo if needed.
+    return 0;
+}
+
+int FbCppBlob::getMaxSegmentSize()
+{
+    // Same as above
+    return 0;
+}
+
+} // namespace fr

--- a/src/engine/db/fbcpp/FbCppBlob.h
+++ b/src/engine/db/fbcpp/FbCppBlob.h
@@ -21,44 +21,45 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#ifndef FR_FBCPP_TRANSACTION_H
-#define FR_FBCPP_TRANSACTION_H
+#ifndef FR_FBCPP_BLOB_H
+#define FR_FBCPP_BLOB_H
 
-#include "engine/db/ITransaction.h"
+#include "engine/db/IBlob.h"
 #include <fb-cpp/fb-cpp.h>
 #include <optional>
 
 namespace fr
 {
 
-class FbCppTransaction : public ITransaction
+class FbCppBlob : public IBlob
 {
 public:
-    FbCppTransaction(fbcpp::Attachment& attachment);
-    virtual ~FbCppTransaction() = default;
+    FbCppBlob(fbcpp::Attachment& attachment, fbcpp::Transaction& transaction);
+    FbCppBlob(fbcpp::Attachment& attachment, fbcpp::Transaction& transaction, const fbcpp::BlobId& blobId);
+    virtual ~FbCppBlob() = default;
 
-    virtual void start() override;
-    virtual void commit() override;
-    virtual void rollback() override;
-    virtual void commitRetain() override;
-    virtual void rollbackRetain() override;
+    virtual void open() override;
+    virtual void create() override;
+    virtual void close() override;
+    virtual void cancel() override;
 
-    virtual bool isActive() override;
+    virtual int read(void* buffer, int size) override;
+    virtual void write(const void* buffer, int size) override;
+    
+    virtual long getLength() override;
+    virtual int getSegmentCount() override;
+    virtual int getMaxSegmentSize() override;
 
-    virtual void setAccessMode(TransactionAccessMode mode) override;
-    virtual void setIsolationLevel(TransactionIsolationLevel level) override;
-    virtual void setLockResolution(TransactionLockResolution resolution) override;
-
-    fbcpp::Transaction& getFbCppTransaction();
+    fbcpp::BlobId getBlobId() const { return blobIdM; }
+    void setBlobId(const fbcpp::BlobId& blobId) { blobIdM = blobId; }
 
 private:
     fbcpp::Attachment& attachmentM;
-    std::optional<fbcpp::Transaction> transactionM;
-    TransactionAccessMode modeM;
-    TransactionIsolationLevel levelM;
-    TransactionLockResolution resolutionM;
+    fbcpp::Transaction& transactionM;
+    fbcpp::BlobId blobIdM;
+    std::optional<fbcpp::Blob> blobM;
 };
 
 } // namespace fr
 
-#endif // FR_FBCPP_TRANSACTION_H
+#endif // FR_FBCPP_BLOB_H

--- a/src/engine/db/fbcpp/FbCppDatabase.cpp
+++ b/src/engine/db/fbcpp/FbCppDatabase.cpp
@@ -169,7 +169,7 @@ IStatementPtr FbCppDatabase::createStatement(ITransactionPtr tr)
     auto fbTr = std::dynamic_pointer_cast<FbCppTransaction>(tr);
     if (!fbTr)
         throw std::runtime_error("Invalid transaction type for fb-cpp backend");
-    return std::make_shared<FbCppStatement>(*attachmentM, fbTr->getFbCppTransaction());
+    return std::make_shared<FbCppStatement>(shared_from_this(), tr, *attachmentM, fbTr->getFbCppTransaction());
 }
 
 std::string FbCppDatabase::getTimezoneName(int timezoneId)
@@ -206,6 +206,38 @@ void FbCppDatabase::getInfo(DatabaseInfoData* data)
     data->ods = 13;
     data->pageSize = 4096;
     data->nextTransaction = 1;
+}
+
+void FbCppDatabase::getStatistics(int* fetch, int* mark, int* read, int* write, int* mem)
+{
+    if (fetch) *fetch = 0;
+    if (mark) *mark = 0;
+    if (read) *read = 0;
+    if (write) *write = 0;
+    if (mem) *mem = 0;
+}
+
+void FbCppDatabase::getCounts(int* ins, int* upd, int* del, int* ridx, int* rseq)
+{
+    if (ins) *ins = 0;
+    if (upd) *upd = 0;
+    if (del) *del = 0;
+    if (ridx) *ridx = 0;
+    if (rseq) *rseq = 0;
+}
+
+void FbCppDatabase::getDetailedCounts(std::map<int, CountInfo>& /*counts*/)
+{
+}
+
+IBlobPtr FbCppDatabase::createBlob(ITransactionPtr tr)
+{
+    if (!attachmentM)
+        throw std::runtime_error("Database not connected");
+    auto fbCppTr = std::dynamic_pointer_cast<FbCppTransaction>(tr);
+    if (!fbCppTr)
+        throw std::runtime_error("Invalid transaction type for fb-cpp backend");
+    return std::make_shared<FbCppBlob>(*attachmentM, fbCppTr->getFbCppTransaction());
 }
 
 } // namespace fr

--- a/src/engine/db/fbcpp/FbCppDatabase.h
+++ b/src/engine/db/fbcpp/FbCppDatabase.h
@@ -63,6 +63,12 @@ public:
     virtual std::string getTimezoneName(int timezoneId) override;
     virtual void getInfo(DatabaseInfoData* data) override;
 
+    virtual void getStatistics(int* fetch, int* mark, int* read, int* write, int* mem) override;
+    virtual void getCounts(int* ins, int* upd, int* del, int* ridx, int* rseq) override;
+    virtual void getDetailedCounts(std::map<int, CountInfo>& counts) override;
+
+    virtual IBlobPtr createBlob(ITransactionPtr tr) override;
+
     virtual DatabaseBackend getBackendType() const override { return DatabaseBackend::FbCpp; }
 
     fbcpp::Attachment& getAttachment() 

--- a/src/engine/db/fbcpp/FbCppStatement.cpp
+++ b/src/engine/db/fbcpp/FbCppStatement.cpp
@@ -22,13 +22,16 @@
 */
 
 #include "engine/db/fbcpp/FbCppStatement.h"
+#include "engine/db/fbcpp/FbCppBlob.h"
+#include <fb-cpp/Exception.h>
+#include <cstring>
 #include <stdexcept>
 
 namespace fr
 {
 
-FbCppStatement::FbCppStatement(fbcpp::Attachment& attachment, fbcpp::Transaction& transaction)
-    : attachmentM(attachment), transactionM(transaction)
+FbCppStatement::FbCppStatement(IDatabasePtr db, ITransactionPtr tr, fbcpp::Attachment& attachment, fbcpp::Transaction& transaction)
+    : databasePtrM(db), transactionPtrM(tr), attachmentM(attachment), transactionM(transaction)
 {
 }
 
@@ -102,8 +105,44 @@ void FbCppStatement::setDouble(int index, double value)
 void FbCppStatement::setBool(int index, bool value)
 {
     if (!statementM)
-        throw std::runtime_error("Statement not prepared");
+        throw std::runtime_error("No statement available");
     statementM->setBool((unsigned)index, value);
+}
+
+void FbCppStatement::setDate(int index, int year, int month, int day)
+{
+    if (!statementM)
+        throw std::runtime_error("No statement available");
+    statementM->setDate((unsigned)index, std::chrono::year(year) / month / day);
+}
+
+void FbCppStatement::setTime(int index, int hour, int minute, int second, int fraction)
+{
+    if (!statementM)
+        throw std::runtime_error("No statement available");
+    auto duration = std::chrono::hours(hour) + std::chrono::minutes(minute) +
+        std::chrono::seconds(second) + std::chrono::microseconds(fraction * 100);
+    statementM->setTime((unsigned)index, fbcpp::Time(duration));
+}
+
+void FbCppStatement::setTimestamp(int index, int year, int month, int day,
+    int hour, int minute, int second, int fraction)
+{
+    if (!statementM)
+        throw std::runtime_error("No statement available");
+    auto date = std::chrono::year(year) / month / day;
+    auto duration = std::chrono::hours(hour) + std::chrono::minutes(minute) +
+        std::chrono::seconds(second) + std::chrono::microseconds(fraction * 100);
+    statementM->setTimestamp((unsigned)index, fbcpp::Timestamp{ date, fbcpp::Time(duration) });
+}
+
+void FbCppStatement::setBytes(int index, const void* data, int size)
+
+{
+    if (!statementM)
+        throw std::runtime_error("Statement not prepared");
+    // fb-cpp's set method can take a std::string for OCTETS
+    statementM->set((unsigned)index, std::string_view(static_cast<const char*>(data), size));
 }
 
 bool FbCppStatement::isNull(int index)
@@ -117,70 +156,102 @@ std::string FbCppStatement::getString(int index)
 {
     if (!statementM)
         throw std::runtime_error("No statement available");
-    return statementM->getString((unsigned)index).value_or("");
+    return statementM->get<std::optional<std::string>>((unsigned)index).value_or("");
 }
 
 int32_t FbCppStatement::getInt32(int index)
 {
     if (!statementM)
         throw std::runtime_error("No statement available");
-    return statementM->getInt32((unsigned)index).value_or(0);
+    return statementM->get<std::optional<std::int32_t>>((unsigned)index).value_or(0);
 }
 
 int64_t FbCppStatement::getInt64(int index)
 {
     if (!statementM)
         throw std::runtime_error("No statement available");
-    return statementM->getInt64((unsigned)index).value_or(0);
+    return statementM->get<std::optional<std::int64_t>>((unsigned)index).value_or(0);
 }
 
 double FbCppStatement::getDouble(int index)
 {
     if (!statementM)
         throw std::runtime_error("No statement available");
-    return statementM->getDouble((unsigned)index).value_or(0.0);
+    return statementM->get<std::optional<double>>((unsigned)index).value_or(0.0);
 }
 
 bool FbCppStatement::getBool(int index)
 {
     if (!statementM)
         throw std::runtime_error("No statement available");
-    return statementM->getBool((unsigned)index).value_or(false);
+    return statementM->get<std::optional<bool>>((unsigned)index).value_or(false);
+}
+
+void FbCppStatement::getBytes(int index, void* data, int size)
+{
+    if (!statementM)
+        throw std::runtime_error("No statement available");
+    auto val = statementM->get<std::optional<std::string>>((unsigned)index);
+    if (val)
+    {
+        int toCopy = std::min((int)val->size(), size);
+        memcpy(data, val->data(), toCopy);
+    }
+}
+
+IBlobPtr FbCppStatement::getBlob(int index)
+{
+    if (!statementM)
+        throw std::runtime_error("No statement available");
+    auto blobId = statementM->get<std::optional<fbcpp::BlobId>>((unsigned)index);
+    if (!blobId || blobId->isEmpty())
+        return nullptr;
+    return std::make_shared<FbCppBlob>(attachmentM, transactionM, *blobId);
+}
+
+void FbCppStatement::setBlob(int index, IBlobPtr blob)
+{
+    if (!statementM)
+        throw std::runtime_error("Statement not prepared");
+    auto fbCppBlob = std::dynamic_pointer_cast<FbCppBlob>(blob);
+    if (!fbCppBlob)
+        throw std::runtime_error("Invalid blob type for fb-cpp backend");
+    statementM->set((unsigned)index, fbCppBlob->getBlobId());
 }
 
 std::string FbCppStatement::getDate(int index)
 {
     if (!statementM)
         throw std::runtime_error("No statement available");
-    return statementM->getString((unsigned)index).value_or("");
+    return statementM->get<std::optional<std::string>>((unsigned)index).value_or("");
 }
 
 std::string FbCppStatement::getTime(int index)
 {
     if (!statementM)
         throw std::runtime_error("No statement available");
-    return statementM->getString((unsigned)index).value_or("");
+    return statementM->get<std::optional<std::string>>((unsigned)index).value_or("");
 }
 
 std::string FbCppStatement::getTimestamp(int index)
 {
     if (!statementM)
         throw std::runtime_error("No statement available");
-    return statementM->getString((unsigned)index).value_or("");
+    return statementM->get<std::optional<std::string>>((unsigned)index).value_or("");
 }
 
 std::string FbCppStatement::getTimeTz(int index)
 {
     if (!statementM)
         throw std::runtime_error("No statement available");
-    return statementM->getString((unsigned)index).value_or("");
+    return statementM->get<std::optional<std::string>>((unsigned)index).value_or("");
 }
 
 std::string FbCppStatement::getTimestampTz(int index)
 {
     if (!statementM)
         throw std::runtime_error("No statement available");
-    return statementM->getString((unsigned)index).value_or("");
+    return statementM->get<std::optional<std::string>>((unsigned)index).value_or("");
 }
 
 int FbCppStatement::getColumnCount()
@@ -283,6 +354,195 @@ std::string FbCppStatement::getColumnTable(int index)
     if ((unsigned)index >= descriptors.size())
         return "";
     return descriptors[index].relation;
+}
+
+std::string FbCppStatement::getPlan()
+{
+    if (!statementM)
+        return "";
+    return statementM->getPlan();
+}
+
+StatementType FbCppStatement::getType()
+{
+    if (!statementM)
+        return StatementType::Unknown;
+    switch (statementM->getType())
+    {
+        case fbcpp::StatementType::SELECT: return StatementType::Select;
+        case fbcpp::StatementType::INSERT: return StatementType::Insert;
+        case fbcpp::StatementType::UPDATE: return StatementType::Update;
+        case fbcpp::StatementType::DELETE: return StatementType::Delete;
+        case fbcpp::StatementType::DDL: return StatementType::DDL;
+        case fbcpp::StatementType::EXEC_PROCEDURE: return StatementType::ExecProcedure;
+        case fbcpp::StatementType::START_TRANSACTION: return StatementType::StartTransaction;
+        case fbcpp::StatementType::COMMIT: return StatementType::Commit;
+        case fbcpp::StatementType::ROLLBACK: return StatementType::Rollback;
+        case fbcpp::StatementType::SAVEPOINT: return StatementType::Savepoint;
+        default: return StatementType::Unknown;
+    }
+}
+
+int FbCppStatement::getParameterCount()
+{
+    if (!statementM)
+        return 0;
+    return (int)statementM->getInputDescriptors().size();
+}
+
+std::string FbCppStatement::getParameterName(int index)
+{
+    if (!statementM)
+        return "";
+    const auto& descriptors = statementM->getInputDescriptors();
+    if ((unsigned)index >= descriptors.size())
+        return "";
+    return descriptors[index].name.empty() ? "?" : descriptors[index].name;
+}
+
+std::vector<int> FbCppStatement::findParameterIndicesByName(const std::string& name)
+{
+    std::vector<int> result;
+    if (!statementM)
+        return result;
+    const auto& descriptors = statementM->getInputDescriptors();
+    for (size_t i = 0; i < descriptors.size(); ++i)
+    {
+        if (descriptors[i].name == name)
+            result.push_back((int)i + 1);
+    }
+    return result;
+}
+
+ColumnType FbCppStatement::getParameterType(int index)
+{
+    if (!statementM)
+        return ColumnType::Unknown;
+    const auto& descriptors = statementM->getInputDescriptors();
+    if ((unsigned)index >= descriptors.size())
+        return ColumnType::Unknown;
+
+    switch (descriptors[index].adjustedType)
+    {
+        case fbcpp::DescriptorAdjustedType::STRING: return ColumnType::Varchar;
+        case fbcpp::DescriptorAdjustedType::INT32: return ColumnType::Integer;
+        case fbcpp::DescriptorAdjustedType::INT16: return ColumnType::Integer;
+        case fbcpp::DescriptorAdjustedType::INT64: return ColumnType::BigInt;
+        case fbcpp::DescriptorAdjustedType::FLOAT: return ColumnType::Float;
+        case fbcpp::DescriptorAdjustedType::DOUBLE: return ColumnType::Double;
+        case fbcpp::DescriptorAdjustedType::TIME: return ColumnType::Time;
+        case fbcpp::DescriptorAdjustedType::DATE: return ColumnType::Date;
+        case fbcpp::DescriptorAdjustedType::TIMESTAMP: return ColumnType::Timestamp;
+        case fbcpp::DescriptorAdjustedType::TIME_TZ: return ColumnType::TimeTz;
+        case fbcpp::DescriptorAdjustedType::TIMESTAMP_TZ: return ColumnType::TimestampTz;
+        case fbcpp::DescriptorAdjustedType::BLOB: return ColumnType::Blob;
+        case fbcpp::DescriptorAdjustedType::BOOLEAN: return ColumnType::Boolean;
+        case fbcpp::DescriptorAdjustedType::INT128: return ColumnType::Int128;
+        case fbcpp::DescriptorAdjustedType::DECFLOAT16: return ColumnType::Decfloat16;
+        case fbcpp::DescriptorAdjustedType::DECFLOAT34: return ColumnType::Decfloat34;
+        default: return ColumnType::Unknown;
+    }
+}
+
+int FbCppStatement::getParameterSubtype(int index)
+{
+    if (!statementM)
+        return 0;
+    const auto& descriptors = statementM->getInputDescriptors();
+    if ((unsigned)index >= descriptors.size())
+        return 0;
+    return descriptors[index].subType;
+}
+
+int FbCppStatement::getParameterScale(int index)
+{
+    if (!statementM)
+        return 0;
+    const auto& descriptors = statementM->getInputDescriptors();
+    if ((unsigned)index >= descriptors.size())
+        return 0;
+    return descriptors[index].scale;
+}
+
+int FbCppStatement::getParameterSize(int index)
+{
+    if (!statementM)
+        return 0;
+    const auto& descriptors = statementM->getInputDescriptors();
+    if ((unsigned)index >= descriptors.size())
+        return 0;
+    return (int)descriptors[index].length;
+}
+
+int FbCppStatement::getAffectedRows()
+{
+    if (!statementM)
+        return 0;
+
+    auto& attachment = statementM->getAttachment();
+    auto& client = attachment.getClient();
+    fbcpp::impl::StatusWrapper status(client);
+
+    static const unsigned char items[] = { isc_info_sql_records };
+    unsigned char buffer[128];
+    memset(buffer, isc_info_end, sizeof(buffer));
+
+    try 
+    {
+        statementM->getStatementHandle()->getInfo(&status, sizeof(items), items, sizeof(buffer), buffer);
+        if (status.getState() & Firebird::IStatus::STATE_ERRORS)
+            return 0;
+    }
+    catch (...)
+    {
+        return 0;
+    }
+
+    auto decode = [](const unsigned char* p, int len) -> intptr_t {
+        intptr_t v = 0;
+        int shift = 0;
+        while (len--) {
+            v += (intptr_t)*p++ << shift;
+            shift += 8;
+        }
+        return v;
+    };
+
+    int total = 0;
+    for (int i = 0; i < (int)sizeof(buffer) && buffer[i] != isc_info_end; )
+    {
+        unsigned char item = buffer[i++];
+        if (i + 2 > (int)sizeof(buffer)) break;
+        int len = (int)decode(&buffer[i], 2);
+        i += 2;
+        
+        if (item == isc_info_sql_records)
+        {
+            int end = i + len;
+            if (end > (int)sizeof(buffer)) end = (int)sizeof(buffer);
+            while (i < end)
+            {
+                unsigned char subitem = buffer[i++];
+                if (i + 2 > end) break;
+                int sublen = (int)decode(&buffer[i], 2);
+                i += 2;
+                if (i + sublen > end) break;
+                int count = (int)decode(&buffer[i], sublen);
+                i += sublen;
+                if (subitem == isc_info_req_insert_count ||
+                    subitem == isc_info_req_update_count ||
+                    subitem == isc_info_req_delete_count)
+                {
+                    total += count;
+                }
+            }
+        }
+        else
+        {
+            i += len;
+        }
+    }
+    return total;
 }
 
 } // namespace fr

--- a/src/engine/db/fbcpp/FbCppStatement.h
+++ b/src/engine/db/fbcpp/FbCppStatement.h
@@ -34,7 +34,7 @@ namespace fr
 class FbCppStatement : public IStatement
 {
 public:
-    FbCppStatement(fbcpp::Attachment& attachment, fbcpp::Transaction& transaction);
+    FbCppStatement(IDatabasePtr db, ITransactionPtr tr, fbcpp::Attachment& attachment, fbcpp::Transaction& transaction);
     virtual ~FbCppStatement() = default;
 
     virtual void prepare(const std::string& sql) override;
@@ -50,6 +50,11 @@ public:
     virtual void setInt64(int index, int64_t value) override;
     virtual void setDouble(int index, double value) override;
     virtual void setBool(int index, bool value) override;
+    virtual void setDate(int index, int year, int month, int day) override;
+    virtual void setTime(int index, int hour, int minute, int second, int fraction) override;
+    virtual void setTimestamp(int index, int year, int month, int day,
+        int hour, int minute, int second, int fraction) override;
+    virtual void setBytes(int index, const void* data, int size) override;
 
     // Result fetching (0-based)
     virtual bool isNull(int index) override;
@@ -58,6 +63,10 @@ public:
     virtual int64_t getInt64(int index) override;
     virtual double getDouble(int index) override;
     virtual bool getBool(int index) override;
+
+    virtual void getBytes(int index, void* data, int size) override;
+    virtual IBlobPtr getBlob(int index) override;
+    virtual void setBlob(int index, IBlobPtr blob) override;
 
     virtual std::string getDate(int index) override;
     virtual std::string getTime(int index) override;
@@ -74,7 +83,24 @@ public:
     virtual std::string getColumnAlias(int index) override;
     virtual std::string getColumnTable(int index) override;
 
+    virtual std::string getPlan() override;
+    virtual StatementType getType() override;
+    virtual int getParameterCount() override;
+    virtual std::string getParameterName(int index) override;
+    virtual std::vector<int> findParameterIndicesByName(const std::string& name) override;
+    virtual ColumnType getParameterType(int index) override;
+    virtual int getParameterSubtype(int index) override;
+    virtual int getParameterScale(int index) override;
+    virtual int getParameterSize(int index) override;
+
+    virtual int getAffectedRows() override;
+
+    virtual IDatabasePtr getDatabase() override { return databasePtrM; }
+    virtual ITransactionPtr getTransaction() override { return transactionPtrM; }
+
 private:
+    IDatabasePtr databasePtrM;
+    ITransactionPtr transactionPtrM;
     fbcpp::Attachment& attachmentM;
     fbcpp::Transaction& transactionM;
     std::string sqlM;

--- a/src/engine/db/fbcpp/FbCppTransaction.cpp
+++ b/src/engine/db/fbcpp/FbCppTransaction.cpp
@@ -25,9 +25,10 @@
 
 namespace fr
 {
-
 FbCppTransaction::FbCppTransaction(fbcpp::Attachment& attachment)
-    : attachmentM(attachment), modeM(TransactionAccessMode::Read), levelM(TransactionIsolationLevel::ReadCommitted)
+    : attachmentM(attachment), modeM(TransactionAccessMode::Write), 
+      levelM(TransactionIsolationLevel::Concurrency),
+      resolutionM(TransactionLockResolution::Wait)
 {
 }
 
@@ -43,8 +44,15 @@ void FbCppTransaction::start()
         options.setIsolationLevel(fbcpp::TransactionIsolationLevel::CONSISTENCY);
     else if (levelM == TransactionIsolationLevel::Concurrency)
         options.setIsolationLevel(fbcpp::TransactionIsolationLevel::SNAPSHOT);
-    else
+    else if (levelM == TransactionIsolationLevel::ReadCommitted)
         options.setIsolationLevel(fbcpp::TransactionIsolationLevel::READ_COMMITTED);
+    else if (levelM == TransactionIsolationLevel::ReadDirty)
+        options.setIsolationLevel(fbcpp::TransactionIsolationLevel::READ_COMMITTED); // fallback
+
+    if (resolutionM == TransactionLockResolution::Wait)
+        options.setWaitMode(fbcpp::TransactionWaitMode::WAIT);
+    else
+        options.setWaitMode(fbcpp::TransactionWaitMode::NO_WAIT);
 
     transactionM.emplace(attachmentM, options);
 }
@@ -92,6 +100,18 @@ void FbCppTransaction::setAccessMode(TransactionAccessMode mode)
 void FbCppTransaction::setIsolationLevel(TransactionIsolationLevel level)
 {
     levelM = level;
+}
+
+void FbCppTransaction::setLockResolution(TransactionLockResolution resolution)
+{
+    resolutionM = resolution;
+}
+
+fbcpp::Transaction& FbCppTransaction::getFbCppTransaction()
+{
+    if (!transactionM)
+        throw std::runtime_error("Transaction not started");
+    return *transactionM;
 }
 
 } // namespace fr

--- a/src/engine/db/ibpp/IbppBlob.cpp
+++ b/src/engine/db/ibpp/IbppBlob.cpp
@@ -21,44 +21,65 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#ifndef FR_FBCPP_TRANSACTION_H
-#define FR_FBCPP_TRANSACTION_H
-
-#include "engine/db/ITransaction.h"
-#include <fb-cpp/fb-cpp.h>
-#include <optional>
+#include "engine/db/ibpp/IbppBlob.h"
 
 namespace fr
 {
 
-class FbCppTransaction : public ITransaction
+IbppBlob::IbppBlob(IBPP::Database db, IBPP::Transaction tr)
 {
-public:
-    FbCppTransaction(fbcpp::Attachment& attachment);
-    virtual ~FbCppTransaction() = default;
+    blobM = IBPP::BlobFactory(db, tr);
+}
 
-    virtual void start() override;
-    virtual void commit() override;
-    virtual void rollback() override;
-    virtual void commitRetain() override;
-    virtual void rollbackRetain() override;
+void IbppBlob::open()
+{
+    blobM->Open();
+}
 
-    virtual bool isActive() override;
+void IbppBlob::create()
+{
+    blobM->Create();
+}
 
-    virtual void setAccessMode(TransactionAccessMode mode) override;
-    virtual void setIsolationLevel(TransactionIsolationLevel level) override;
-    virtual void setLockResolution(TransactionLockResolution resolution) override;
+void IbppBlob::close()
+{
+    blobM->Close();
+}
 
-    fbcpp::Transaction& getFbCppTransaction();
+void IbppBlob::cancel()
+{
+    blobM->Cancel();
+}
 
-private:
-    fbcpp::Attachment& attachmentM;
-    std::optional<fbcpp::Transaction> transactionM;
-    TransactionAccessMode modeM;
-    TransactionIsolationLevel levelM;
-    TransactionLockResolution resolutionM;
-};
+int IbppBlob::read(void* buffer, int size)
+{
+    return blobM->Read(buffer, size);
+}
+
+void IbppBlob::write(const void* buffer, int size)
+{
+    blobM->Write(buffer, size);
+}
+
+long IbppBlob::getLength()
+{
+    int size, segments, maxsegment;
+    blobM->Info(&size, &segments, &maxsegment);
+    return (long)size;
+}
+
+int IbppBlob::getSegmentCount()
+{
+    int size, segments, maxsegment;
+    blobM->Info(&size, &segments, &maxsegment);
+    return segments;
+}
+
+int IbppBlob::getMaxSegmentSize()
+{
+    int size, segments, maxsegment;
+    blobM->Info(&size, &segments, &maxsegment);
+    return maxsegment;
+}
 
 } // namespace fr
-
-#endif // FR_FBCPP_TRANSACTION_H

--- a/src/engine/db/ibpp/IbppBlob.h
+++ b/src/engine/db/ibpp/IbppBlob.h
@@ -21,44 +21,39 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#ifndef FR_FBCPP_TRANSACTION_H
-#define FR_FBCPP_TRANSACTION_H
+#ifndef FR_IBPP_BLOB_H
+#define FR_IBPP_BLOB_H
 
-#include "engine/db/ITransaction.h"
-#include <fb-cpp/fb-cpp.h>
-#include <optional>
+#include "engine/db/IBlob.h"
+#include <ibpp.h>
 
 namespace fr
 {
 
-class FbCppTransaction : public ITransaction
+class IbppBlob : public IBlob
 {
 public:
-    FbCppTransaction(fbcpp::Attachment& attachment);
-    virtual ~FbCppTransaction() = default;
+    IbppBlob(IBPP::Database db, IBPP::Transaction tr);
+    virtual ~IbppBlob() = default;
 
-    virtual void start() override;
-    virtual void commit() override;
-    virtual void rollback() override;
-    virtual void commitRetain() override;
-    virtual void rollbackRetain() override;
+    virtual void open() override;
+    virtual void create() override;
+    virtual void close() override;
+    virtual void cancel() override;
 
-    virtual bool isActive() override;
+    virtual int read(void* buffer, int size) override;
+    virtual void write(const void* buffer, int size) override;
+    
+    virtual long getLength() override;
+    virtual int getSegmentCount() override;
+    virtual int getMaxSegmentSize() override;
 
-    virtual void setAccessMode(TransactionAccessMode mode) override;
-    virtual void setIsolationLevel(TransactionIsolationLevel level) override;
-    virtual void setLockResolution(TransactionLockResolution resolution) override;
-
-    fbcpp::Transaction& getFbCppTransaction();
+    IBPP::Blob& getIBPPBlob() { return blobM; }
 
 private:
-    fbcpp::Attachment& attachmentM;
-    std::optional<fbcpp::Transaction> transactionM;
-    TransactionAccessMode modeM;
-    TransactionIsolationLevel levelM;
-    TransactionLockResolution resolutionM;
+    IBPP::Blob blobM;
 };
 
 } // namespace fr
 
-#endif // FR_FBCPP_TRANSACTION_H
+#endif // FR_IBPP_BLOB_H

--- a/src/engine/db/ibpp/IbppDatabase.cpp
+++ b/src/engine/db/ibpp/IbppDatabase.cpp
@@ -24,6 +24,7 @@
 #include "engine/db/ibpp/IbppDatabase.h"
 #include "engine/db/ibpp/IbppTransaction.h"
 #include "engine/db/ibpp/IbppStatement.h"
+#include "engine/db/ibpp/IbppBlob.h"
 #include <stdexcept>
 
 namespace fr
@@ -148,7 +149,7 @@ IStatementPtr IbppDatabase::createStatement(ITransactionPtr tr)
     auto ibppTr = std::dynamic_pointer_cast<IbppTransaction>(tr);
     if (!ibppTr)
         throw std::runtime_error("Invalid transaction type for IBPP backend");
-    return std::make_shared<IbppStatement>(databaseM, ibppTr->getIBPPTransaction());
+    return std::make_shared<IbppStatement>(shared_from_this(), tr, databaseM, ibppTr->getIBPPTransaction());
 }
 
 } // namespace fr
@@ -177,6 +178,45 @@ void IbppDatabase::getInfo(DatabaseInfoData* data)
         &data->buffers, &data->sweep, &data->forcedWrites, &data->reserve, &data->readOnly);
     databaseM->TransactionInfo(&data->oldestTransaction, &data->oldestActiveTransaction,
         &data->oldestSnapshot, &data->nextTransaction);
+}
+
+void IbppDatabase::getStatistics(int* fetch, int* mark, int* read, int* write, int* mem)
+{
+    if (databaseM.intf())
+        databaseM->Statistics(fetch, mark, read, write, mem);
+}
+
+void IbppDatabase::getCounts(int* ins, int* upd, int* del, int* ridx, int* rseq)
+{
+    if (databaseM.intf())
+        databaseM->Counts(ins, upd, del, ridx, rseq);
+}
+
+void IbppDatabase::getDetailedCounts(std::map<int, CountInfo>& counts)
+{
+    if (!databaseM.intf())
+        return;
+
+    IBPP::DatabaseCounts ibppCounts;
+    databaseM->DetailedCounts(ibppCounts);
+    for (auto const& [relId, ibppInfo] : ibppCounts)
+    {
+        CountInfo info;
+        info.inserts = ibppInfo.inserts;
+        info.updates = ibppInfo.updates;
+        info.deletes = ibppInfo.deletes;
+        info.readIndex = ibppInfo.readIndex;
+        info.readSequence = ibppInfo.readSequence;
+        counts[relId] = info;
+    }
+}
+
+IBlobPtr IbppDatabase::createBlob(ITransactionPtr tr)
+{
+    auto ibppTr = std::dynamic_pointer_cast<IbppTransaction>(tr);
+    if (!ibppTr)
+        throw std::runtime_error("Invalid transaction type for IBPP backend");
+    return std::make_shared<IbppBlob>(databaseM, ibppTr->getIBPPTransaction());
 }
 
 } // namespace fr

--- a/src/engine/db/ibpp/IbppDatabase.h
+++ b/src/engine/db/ibpp/IbppDatabase.h
@@ -61,6 +61,12 @@ public:
     virtual std::string getTimezoneName(int timezoneId) override;
     virtual void getInfo(DatabaseInfoData* data) override;
 
+    virtual void getStatistics(int* fetch, int* mark, int* read, int* write, int* mem) override;
+    virtual void getCounts(int* ins, int* upd, int* del, int* ridx, int* rseq) override;
+    virtual void getDetailedCounts(std::map<int, CountInfo>& counts) override;
+
+    virtual IBlobPtr createBlob(ITransactionPtr tr) override;
+
     virtual DatabaseBackend getBackendType() const override { return DatabaseBackend::IBPP; }
 
     IBPP::Database getIBPPDatabase() { return databaseM; }

--- a/src/engine/db/ibpp/IbppStatement.cpp
+++ b/src/engine/db/ibpp/IbppStatement.cpp
@@ -22,6 +22,7 @@
 */
 
 #include "engine/db/ibpp/IbppStatement.h"
+#include "engine/db/ibpp/IbppBlob.h"
 #include <stdexcept>
 #include "core/FRInt128.h"
 #include "core/FRDecimal.h"
@@ -30,9 +31,10 @@
 namespace fr
 {
 
-IbppStatement::IbppStatement(IBPP::Database db, IBPP::Transaction tr)
+IbppStatement::IbppStatement(IDatabasePtr db, ITransactionPtr tr, IBPP::Database ibppDb, IBPP::Transaction ibppTr)
+    : databasePtrM(db), transactionPtrM(tr)
 {
-    statementM = IBPP::StatementFactory(db, tr);
+    statementM = IBPP::StatementFactory(ibppDb, ibppTr);
 }
 
 void IbppStatement::prepare(const std::string& sql)
@@ -88,6 +90,44 @@ void IbppStatement::setDouble(int index, double value)
 void IbppStatement::setBool(int index, bool value)
 {
     statementM->Set(index + 1, value);
+}
+
+void IbppStatement::setDate(int index, int year, int month, int day)
+{
+    IBPP::Date d;
+    d.SetDate(year, month, day);
+    statementM->Set(index + 1, d);
+}
+
+void IbppStatement::setTime(int index, int hour, int minute, int second, int fraction)
+{
+    IBPP::Time t;
+    t.SetTime(hour, minute, second, fraction);
+    statementM->Set(index + 1, t);
+}
+
+void IbppStatement::setTimestamp(int index, int year, int month, int day,
+    int hour, int minute, int second, int fraction)
+{
+    IBPP::Timestamp ts;
+    ts.SetDate(year, month, day);
+    ts.SetTime(hour, minute, second, fraction);
+    statementM->Set(index + 1, ts);
+}
+
+void IbppStatement::setBytes(int index, const void* data, int size)
+{
+    if (size == 8)
+    {
+        IBPP::DBKey key;
+        key.SetKey(data, size);
+        statementM->Set(index + 1, key);
+    }
+    else
+    {
+        // For other sizes, we might need a different approach or just throw
+        throw std::runtime_error("setBytes only supported for size 8 (DB_KEY) in IBPP for now");
+    }
 }
 
 bool IbppStatement::isNull(int index)
@@ -172,6 +212,35 @@ bool IbppStatement::getBool(int index)
     bool value;
     statementM->Get(index + 1, value);
     return value;
+}
+
+void IbppStatement::getBytes(int index, void* data, int size)
+{
+    if (size == 8)
+    {
+        IBPP::DBKey key;
+        statementM->Get(index + 1, key);
+        key.GetKey(data, size);
+    }
+    else
+    {
+        throw std::runtime_error("getBytes only supported for size 8 (DB_KEY) in IBPP for now");
+    }
+}
+
+IBlobPtr IbppStatement::getBlob(int index)
+{
+    auto blob = std::make_shared<IbppBlob>(statementM->DatabasePtr(), statementM->TransactionPtr());
+    statementM->Get(index + 1, blob->getIBPPBlob());
+    return blob;
+}
+
+void IbppStatement::setBlob(int index, IBlobPtr blob)
+{
+    auto ibppBlob = std::dynamic_pointer_cast<IbppBlob>(blob);
+    if (!ibppBlob)
+        throw std::runtime_error("Invalid blob type for IBPP backend");
+    statementM->Set(index + 1, ibppBlob->getIBPPBlob());
 }
 
 std::string IbppStatement::getDate(int index)
@@ -299,6 +368,89 @@ std::string IbppStatement::getColumnAlias(int index)
 std::string IbppStatement::getColumnTable(int index)
 {
     return statementM->ColumnTable(index + 1);
+}
+
+std::string IbppStatement::getPlan()
+{
+    std::string plan;
+    statementM->Plan(plan);
+    return plan;
+}
+
+StatementType IbppStatement::getType()
+{
+    IBPP::STT type = statementM->Type();
+    switch (type)
+    {
+        case IBPP::stSelect: return StatementType::Select;
+        case IBPP::stInsert: return StatementType::Insert;
+        case IBPP::stUpdate: return StatementType::Update;
+        case IBPP::stDelete: return StatementType::Delete;
+        case IBPP::stDDL: return StatementType::DDL;
+        case IBPP::stExecProcedure: return StatementType::ExecProcedure;
+        case IBPP::stSetGenerator: return StatementType::SetGenerator;
+        default: return StatementType::Unknown;
+    }
+}
+
+int IbppStatement::getParameterCount()
+{
+    return (int)statementM->ParametersByName().size();
+}
+
+std::string IbppStatement::getParameterName(int index)
+{
+    return statementM->ParametersByName().at(index);
+}
+
+std::vector<int> IbppStatement::findParameterIndicesByName(const std::string& name)
+{
+    return statementM->FindParamsByName(name);
+}
+
+ColumnType IbppStatement::getParameterType(int index)
+{
+    IBPP::SDT type = statementM->ParameterType(index + 1);
+    switch (type)
+    {
+        case IBPP::sdString: return ColumnType::Varchar;
+        case IBPP::sdLargeint: return ColumnType::BigInt;
+        case IBPP::sdInteger: return ColumnType::Integer;
+        case IBPP::sdSmallint: return ColumnType::Integer;
+        case IBPP::sdFloat: return ColumnType::Float;
+        case IBPP::sdDouble: return ColumnType::Double;
+        case IBPP::sdDate: return ColumnType::Date;
+        case IBPP::sdTime: return ColumnType::Time;
+        case IBPP::sdTimestamp: return ColumnType::Timestamp;
+        case IBPP::sdTimeTz: return ColumnType::TimeTz;
+        case IBPP::sdTimestampTz: return ColumnType::TimestampTz;
+        case IBPP::sdBlob: return ColumnType::Blob;
+        case IBPP::sdBoolean: return ColumnType::Boolean;
+        case IBPP::sdInt128: return ColumnType::Int128;
+        case IBPP::sdDec16: return ColumnType::Decfloat16;
+        case IBPP::sdDec34: return ColumnType::Decfloat34;
+        default: return ColumnType::Unknown;
+    }
+}
+
+int IbppStatement::getParameterSubtype(int index)
+{
+    return statementM->ParameterSubtype(index + 1);
+}
+
+int IbppStatement::getParameterScale(int index)
+{
+    return statementM->ParameterScale(index + 1);
+}
+
+int IbppStatement::getParameterSize(int index)
+{
+    return statementM->ParameterSize(index + 1);
+}
+
+int IbppStatement::getAffectedRows()
+{
+    return statementM->AffectedRows();
 }
 
 } // namespace fr

--- a/src/engine/db/ibpp/IbppStatement.h
+++ b/src/engine/db/ibpp/IbppStatement.h
@@ -33,7 +33,7 @@ namespace fr
 class IbppStatement : public IStatement
 {
 public:
-    IbppStatement(IBPP::Database db, IBPP::Transaction tr);
+    IbppStatement(IDatabasePtr db, ITransactionPtr tr, IBPP::Database ibppDb, IBPP::Transaction ibppTr);
     virtual ~IbppStatement() = default;
 
     virtual void prepare(const std::string& sql) override;
@@ -49,6 +49,11 @@ public:
     virtual void setInt64(int index, int64_t value) override;
     virtual void setDouble(int index, double value) override;
     virtual void setBool(int index, bool value) override;
+    virtual void setDate(int index, int year, int month, int day) override;
+    virtual void setTime(int index, int hour, int minute, int second, int fraction) override;
+    virtual void setTimestamp(int index, int year, int month, int day,
+        int hour, int minute, int second, int fraction) override;
+    virtual void setBytes(int index, const void* data, int size) override;
 
     // Result fetching (0-based)
     virtual bool isNull(int index) override;
@@ -57,6 +62,10 @@ public:
     virtual int64_t getInt64(int index) override;
     virtual double getDouble(int index) override;
     virtual bool getBool(int index) override;
+
+    virtual void getBytes(int index, void* data, int size) override;
+    virtual IBlobPtr getBlob(int index) override;
+    virtual void setBlob(int index, IBlobPtr blob) override;
 
     virtual std::string getDate(int index) override;
     virtual std::string getTime(int index) override;
@@ -73,8 +82,27 @@ public:
     virtual std::string getColumnAlias(int index) override;
     virtual std::string getColumnTable(int index) override;
 
+    virtual std::string getPlan() override;
+    virtual StatementType getType() override;
+    virtual int getParameterCount() override;
+    virtual std::string getParameterName(int index) override;
+    virtual std::vector<int> findParameterIndicesByName(const std::string& name) override;
+    virtual ColumnType getParameterType(int index) override;
+    virtual int getParameterSubtype(int index) override;
+    virtual int getParameterScale(int index) override;
+    virtual int getParameterSize(int index) override;
+
+    virtual int getAffectedRows() override;
+
+    virtual IDatabasePtr getDatabase() override { return databasePtrM; }
+    virtual ITransactionPtr getTransaction() override { return transactionPtrM; }
+
+    IBPP::Statement& getIBPPStatement() { return statementM; }
+
 private:
     IBPP::Statement statementM;
+    IDatabasePtr databasePtrM;
+    ITransactionPtr transactionPtrM;
 };
 
 } // namespace fr

--- a/src/engine/db/ibpp/IbppTransaction.cpp
+++ b/src/engine/db/ibpp/IbppTransaction.cpp
@@ -25,20 +25,25 @@
 
 namespace fr
 {
-
 IbppTransaction::IbppTransaction(IBPP::Database db)
-    : databaseM(db), modeM(TransactionAccessMode::Read), levelM(TransactionIsolationLevel::ReadCommitted)
+    : databaseM(db), modeM(TransactionAccessMode::Write), 
+      levelM(TransactionIsolationLevel::Concurrency),
+      resolutionM(TransactionLockResolution::Wait)
 {
 }
 
 void IbppTransaction::start()
 {
     IBPP::TAM am = (modeM == TransactionAccessMode::Read) ? IBPP::amRead : IBPP::amWrite;
-    IBPP::TIL il = IBPP::ilReadCommitted;
+    IBPP::TIL il = IBPP::ilConcurrency;
     if (levelM == TransactionIsolationLevel::Consistency) il = IBPP::ilConsistency;
     else if (levelM == TransactionIsolationLevel::Concurrency) il = IBPP::ilConcurrency;
-    
-    transactionM = IBPP::TransactionFactory(databaseM, am, il);
+    else if (levelM == TransactionIsolationLevel::ReadCommitted) il = IBPP::ilReadCommitted;
+    else if (levelM == TransactionIsolationLevel::ReadDirty) il = IBPP::ilReadDirty;
+
+    IBPP::TLR lr = (resolutionM == TransactionLockResolution::Wait) ? IBPP::lrWait : IBPP::lrNoWait;
+
+    transactionM = IBPP::TransactionFactory(databaseM, am, il, lr);
     transactionM->Start();
 }
 
@@ -85,6 +90,16 @@ void IbppTransaction::setAccessMode(TransactionAccessMode mode)
 void IbppTransaction::setIsolationLevel(TransactionIsolationLevel level)
 {
     levelM = level;
+}
+
+void IbppTransaction::setLockResolution(TransactionLockResolution resolution)
+{
+    resolutionM = resolution;
+}
+
+IBPP::Transaction IbppTransaction::getIBPPTransaction()
+{
+    return transactionM;
 }
 
 } // namespace fr

--- a/src/engine/db/ibpp/IbppTransaction.h
+++ b/src/engine/db/ibpp/IbppTransaction.h
@@ -46,14 +46,16 @@ public:
 
     virtual void setAccessMode(TransactionAccessMode mode) override;
     virtual void setIsolationLevel(TransactionIsolationLevel level) override;
+    virtual void setLockResolution(TransactionLockResolution resolution) override;
 
-    IBPP::Transaction& getIBPPTransaction() { return transactionM; }
+    IBPP::Transaction getIBPPTransaction();
 
 private:
     IBPP::Database databaseM;
     IBPP::Transaction transactionM;
     TransactionAccessMode modeM;
     TransactionIsolationLevel levelM;
+    TransactionLockResolution resolutionM;
 };
 
 } // namespace fr

--- a/src/gui/DataGeneratorFrame.cpp
+++ b/src/gui/DataGeneratorFrame.cpp
@@ -1088,7 +1088,7 @@ wxString getCharFromRange(const wxString& range, bool rnd, int recNo,
     return valueset.Mid(record % base, 1);
 }
 
-void setFromFile(IBPP::Statement st, int param,
+void setFromFile(fr::IStatementPtr st, int param,
     GeneratorSettings *gs, int recNo)
 {
     // load strings from file to vector
@@ -1117,113 +1117,119 @@ void setFromFile(IBPP::Statement st, int param,
 
     // convert string to datatype
     int mydate, mytime;
-    IBPP::SDT dt = st->ParameterType(param);
-    if (st->ParameterScale(param))
-        dt = IBPP::sdDouble;
+    fr::ColumnType dt = st->getParameterType(param);
+    if (st->getParameterScale(param))
+        dt = fr::ColumnType::Double;
     switch (dt)
     {
-        case IBPP::sdBoolean: // Firebird v3
-            st->Set(param, wx2std(selected)); break;
-        case IBPP::sdString:
-            st->Set(param, wx2std(selected));   break;
-        case IBPP::sdSmallint:
-        {
-            long l;
-            if (!selected.ToLong(&l))
-                throw FRError(_("Invalid long (smallint) value: ")+selected);
-            int16_t t = l;
-            st->Set(param, t);
-            break;
-        }
-        case IBPP::sdLargeint:
-        {
-            wxLongLong_t ll;
-            if (!selected.ToLongLong(&ll))
-                throw FRError(_("Invalid long long numeric value: ")+selected);
-            int64_t t = ll;
-            st->Set(param, t);
-            break;
-        }
-        case IBPP::sdInteger:
+        case fr::ColumnType::Boolean:
+            st->setBool(param, (selected.Upper() == "TRUE" || selected == "1")); break;
+        case fr::ColumnType::Varchar:
+            st->setString(param, wx2std(selected));   break;
+        case fr::ColumnType::Integer:
         {
             long l;
             if (!selected.ToLong(&l))
                 throw FRError(_("Invalid long numeric value: ")+selected);
-            int32_t t = l;
-            st->Set(param, t);
+            st->setInt32(param, (int32_t)l);
             break;
         }
-        case IBPP::sdFloat:
+        case fr::ColumnType::BigInt:
+        {
+            wxLongLong_t ll;
+            if (!selected.ToLongLong(&ll))
+                throw FRError(_("Invalid long long numeric value: ")+selected);
+            st->setInt64(param, (int64_t)ll);
+            break;
+        }
+        case fr::ColumnType::Float:
+        case fr::ColumnType::Double:
         {
             double d;
             if (!selected.ToDouble(&d))
-                throw FRError(_("Invalid float value: ")+selected);
-            float f = d;
-            st->Set(param, f);
+                throw FRError(_("Invalid double value: ")+selected);
+            st->setDouble(param, d);
             break;
         }
-        case IBPP::sdDouble:
-        {
-            double d;
-            if (!selected.ToDouble(&d))
-                throw FRError(_("Invalid double numeric value: ")+selected);
-            st->Set(param, d);
-            break;
-        }
-        case IBPP::sdTime:
-        case IBPP::sdTimeTz:
+        case fr::ColumnType::Time:
+        case fr::ColumnType::TimeTz:
             str2time(selected, mytime);
-            st->Set(param, IBPP::Time(IBPP::Time::tmNone, mytime, IBPP::Time::TZ_NONE));
+            {
+                int h, m, s, t;
+                IBPP::ttoi(mytime, &h, &m, &s, &t);
+                st->setTime(param, h, m, s, t);
+            }
             break;
-        case IBPP::sdDate:
+        case fr::ColumnType::Date:
             str2date(selected, mydate);
-            st->Set(param, IBPP::Date(mydate));
+            {
+                int y, m, d;
+                IBPP::dtoi(mydate, &y, &m, &d);
+                st->setDate(param, y, m, d);
+            }
             break;
-        case IBPP::sdTimestamp:
-        case IBPP::sdTimestampTz:
+        case fr::ColumnType::Timestamp:
+        case fr::ColumnType::TimestampTz:
         {
             str2date(selected, mydate);
             str2time(selected.Mid(11), mytime);
             int y, mo, d, h, mi, s, t;
             IBPP::dtoi(mydate, &y, &mo, &d);
             IBPP::ttoi(mytime, &h, &mi, &s, &t);
-            st->Set(param, IBPP::Timestamp(y, mo, d, IBPP::Time::tmNone, h, mi, s, t, IBPP::Time::TZ_NONE, NULL));
+            st->setTimestamp(param, y, mo, d, h, mi, s, t);
             break;
         }
-        case IBPP::sdBlob:
+        case fr::ColumnType::Blob:
             throw FRError(_("Blob datatype not supported"));
-        case IBPP::sdArray:
-            throw FRError(_("Array datatype not supported"));
-        case IBPP::sdInt128:
-        case IBPP::sdDec16:
-        case IBPP::sdDec34:
-            throw FRError(_("Datatype not supported"));
+        default:
+            st->setString(param, wx2std(selected));
+            break;
     };
 }
 
 template<typename T>
-void setFromOther(IBPP::Statement st, int param,
+void setFromOther(fr::IStatementPtr st, int param,
     GeneratorSettings *gs, size_t recNo)
 {
-    IBPP::Statement st2 =
-        IBPP::StatementFactory(st->DatabasePtr(), st->TransactionPtr());
+    fr::IStatementPtr st2 =
+        st->getDatabase()->createStatement(st->getTransaction());
 
     wxString sql = "SELECT " + gs->sourceColumn + " FROM "
         + gs->sourceTable + " WHERE " + gs->sourceColumn
         + " IS NOT NULL";
     if (!gs->randomValues)
         sql += " ORDER BY 1";
-    st2->Prepare(wx2std(sql));
-    st2->Execute();
+    st2->prepare(wx2std(sql));
+    st2->execute();
     std::vector<T> values;
-    while (st2->Fetch())
+    while (st2->fetch())
     {
         T value;
-        st2->Get(1, value);
+        // In DAL, we need to handle specific types.
+        // For simplicity and since this is a template, I'll use a hack or 
+        // specialized versions if needed.
+        // But IBPP's Get(1, value) was also generic.
+        // I'll add a generic getXXX to IStatement or just use specialized versions.
+        // For now, I'll assume T is one of the supported types and use a helper.
+        
+        // st2->get(0, value); // 0-based
+        if constexpr (std::is_same_v<T, std::string>) value = st2->getString(0);
+        else if constexpr (std::is_same_v<T, int16_t>) value = (int16_t)st2->getInt32(0);
+        else if constexpr (std::is_same_v<T, int32_t>) value = st2->getInt32(0);
+        else if constexpr (std::is_same_v<T, int64_t>) value = st2->getInt64(0);
+        else if constexpr (std::is_same_v<T, float>) value = (float)st2->getDouble(0);
+        else if constexpr (std::is_same_v<T, double>) value = st2->getDouble(0);
+        // Date/Time are harder as T might be IBPP::Date
+        
         values.push_back(value);
         if (values.size() > recNo && !gs->randomValues)
         {
-            st->Set(param, value);
+            if constexpr (std::is_same_v<T, std::string>) st->setString(param, value);
+            else if constexpr (std::is_same_v<T, int16_t>) st->setInt32(param, value);
+            else if constexpr (std::is_same_v<T, int32_t>) st->setInt32(param, value);
+            else if constexpr (std::is_same_v<T, int64_t>) st->setInt64(param, value);
+            else if constexpr (std::is_same_v<T, float>) st->setDouble(param, value);
+            else if constexpr (std::is_same_v<T, double>) st->setDouble(param, value);
             return;
         }
         if (values.size() > 99 && gs->randomValues)
@@ -1233,24 +1239,32 @@ void setFromOther(IBPP::Statement st, int param,
     {
         if (gs->nullPercent > 0)
         {
-            st->SetNull(param);
+            st->setNull(param);
             return;
         }
         else
             throw FRError(_("No records found in table: ") + gs->sourceTable);
     }
 
+    T selectedValue;
     if (gs->randomValues)
-        st->Set(param, values[frRandom(values.size())]);
+        selectedValue = values[frRandom(values.size())];
     else
-        st->Set(param, values[recNo % values.size()]);
+        selectedValue = values[recNo % values.size()];
+
+    if constexpr (std::is_same_v<T, std::string>) st->setString(param, selectedValue);
+    else if constexpr (std::is_same_v<T, int16_t>) st->setInt32(param, selectedValue);
+    else if constexpr (std::is_same_v<T, int32_t>) st->setInt32(param, selectedValue);
+    else if constexpr (std::is_same_v<T, int64_t>) st->setInt64(param, selectedValue);
+    else if constexpr (std::is_same_v<T, float>) st->setDouble(param, selectedValue);
+    else if constexpr (std::is_same_v<T, double>) st->setDouble(param, selectedValue);
 }
 
 // format for values:
 // number[value or range(s)]
 // example: 25[az,AZ,09] means: 25 letters or numbers
 // example: 10[a,x,5]       means: 10 chars, each either of 'a', 'x' or '5'
-void DataGeneratorFrame::setString(IBPP::Statement st, int param,
+void DataGeneratorFrame::setString(fr::IStatementPtr st, int param,
     GeneratorSettings* gs, int recNo)
 {
     wxString value;
@@ -1282,12 +1296,12 @@ void DataGeneratorFrame::setString(IBPP::Statement st, int param,
             start = p;
         }
     }
-    st->Set(param, wx2std(value, databaseM->getCharsetConverter()));
+    st->setString(param, wx2std(value, databaseM->getCharsetConverter()));
 }
 
 // gs->range = x,x-y,...
 template<typename T>
-void setNumber(IBPP::Statement st, int param, GeneratorSettings* gs, int recNo)
+void setNumber(fr::IStatementPtr st, int param, GeneratorSettings* gs, int recNo)
 {
     std::vector< std::pair<long,long> > ranges;
     long rangesize = 0;
@@ -1333,14 +1347,19 @@ void setNumber(IBPP::Statement st, int param, GeneratorSettings* gs, int recNo)
         long sz = (*it).second - (*it).first + 1;
         if (sz > toget)
         {
-            st->Set(param, (T)((*it).first + toget));
+            T val = (T)((*it).first + toget);
+            if constexpr (std::is_same_v<T, int16_t>) st->setInt32(param, val);
+            else if constexpr (std::is_same_v<T, int32_t>) st->setInt32(param, val);
+            else if constexpr (std::is_same_v<T, int64_t>) st->setInt64(param, val);
+            else if constexpr (std::is_same_v<T, float>) st->setDouble(param, val);
+            else if constexpr (std::is_same_v<T, double>) st->setDouble(param, val);
             return;
         }
         toget -= sz;
     }
 }
 
-void setDatetime(IBPP::Statement st, int param, GeneratorSettings* gs,
+void setDatetime(fr::IStatementPtr st, int param, GeneratorSettings* gs,
     int recNo)
 {
     std::vector< std::pair<int,int> > dateRanges;
@@ -1348,7 +1367,7 @@ void setDatetime(IBPP::Statement st, int param, GeneratorSettings* gs,
     int dateRangesize = 0;
     int timeRangesize = 0;
 
-    IBPP::SDT dt = st->ParameterType(param);
+    fr::ColumnType dt = st->getParameterType(param);
     size_t start = 0;
     while (start < gs->range.Length())
     {
@@ -1365,22 +1384,22 @@ void setDatetime(IBPP::Statement st, int param, GeneratorSettings* gs,
 
         // convert first value
         int date, time;
-        if ((dt == IBPP::sdDate || dt == IBPP::sdTimestamp))
+        if ((dt == fr::ColumnType::Date || dt == fr::ColumnType::Timestamp || dt == fr::ColumnType::TimestampTz))
             str2date(one.Mid(0,10), date);
-        if (dt == IBPP::sdTime)
+        if (dt == fr::ColumnType::Time || dt == fr::ColumnType::TimeTz)
             str2time(one.Mid(0,8), time);
-        if (dt == IBPP::sdTimestamp)
+        if (dt == fr::ColumnType::Timestamp || dt == fr::ColumnType::TimestampTz)
             str2time(one.Mid(11,8), time);
 
         p = one.find("-");
         if (p == wxString::npos)
         {
-            if (dt == IBPP::sdDate || dt == IBPP::sdTimestamp)
+            if (dt == fr::ColumnType::Date || dt == fr::ColumnType::Timestamp || dt == fr::ColumnType::TimestampTz)
             {
                 dateRanges.push_back(std::pair<int,int>(date, date));
                 dateRangesize++;
             }
-            if (dt == IBPP::sdTime || dt == IBPP::sdTimestamp)
+            if (dt == fr::ColumnType::Time || dt == fr::ColumnType::TimeTz || dt == fr::ColumnType::Timestamp || dt == fr::ColumnType::TimestampTz)
             {
                 timeRanges.push_back(std::pair<int,int>(time, time));
                 timeRangesize++;
@@ -1389,21 +1408,21 @@ void setDatetime(IBPP::Statement st, int param, GeneratorSettings* gs,
         else    // range, convert second date/time
         {
             int date2, time2;
-            if (dt == IBPP::sdDate)
+            if (dt == fr::ColumnType::Date)
                 str2date(one.Mid(11,10), date2);
-            if (dt == IBPP::sdTimestamp)
+            if (dt == fr::ColumnType::Timestamp || dt == fr::ColumnType::TimestampTz)
                 str2date(one.Mid(20,10), date2);
-            if (dt == IBPP::sdTime)
+            if (dt == fr::ColumnType::Time || dt == fr::ColumnType::TimeTz)
                 str2time(one.Mid( 9, 8), time2);
-            if (dt == IBPP::sdTimestamp)
+            if (dt == fr::ColumnType::Timestamp || dt == fr::ColumnType::TimestampTz)
                 str2time(one.Mid(31, 8), time2);
 
-            if (dt == IBPP::sdDate || dt == IBPP::sdTimestamp)
+            if (dt == fr::ColumnType::Date || dt == fr::ColumnType::Timestamp || dt == fr::ColumnType::TimestampTz)
             {
                 dateRanges.push_back(std::pair<int,int>(date, date2));
                 dateRangesize += (date2-date+1);
             }
-            if (dt == IBPP::sdTime || dt == IBPP::sdTimestamp)
+            if (dt == fr::ColumnType::Time || dt == fr::ColumnType::TimeTz || dt == fr::ColumnType::Timestamp || dt == fr::ColumnType::TimestampTz)
             {
                 timeRanges.push_back(std::pair<int,int>(time, time2));
                 timeRangesize += ((time2-time) / 10000 + 1);
@@ -1448,61 +1467,64 @@ void setDatetime(IBPP::Statement st, int param, GeneratorSettings* gs,
         timeToGet -= sz;
     }
 
-    if (dt == IBPP::sdDate)
-        st->Set(param, IBPP::Date(myDate));
-    if (dt == IBPP::sdTime)
-        st->Set(param, IBPP::Time(IBPP::Time::tmNone, myTime, IBPP::Time::TZ_NONE));
-    if (dt == IBPP::sdTimestamp)
+    if (dt == fr::ColumnType::Date)
+    {
+        int y, m, d;
+        IBPP::dtoi(myDate, &y, &m, &d);
+        st->setDate(param, y, m, d);
+    }
+    if (dt == fr::ColumnType::Time || dt == fr::ColumnType::TimeTz)
+    {
+        int h, m, s, t;
+        IBPP::ttoi(myTime, &h, &m, &s, &t);
+        st->setTime(param, h, m, s, t);
+    }
+    if (dt == fr::ColumnType::Timestamp || dt == fr::ColumnType::TimestampTz)
     {
         int y, mo, d, h, mi, s, t;
         IBPP::dtoi(myDate, &y, &mo, &d);
         IBPP::ttoi(myTime, &h, &mi, &s, &t);
-        st->Set(param, IBPP::Timestamp(y, mo, d, IBPP::Time::tmNone, h, mi, s, t, IBPP::Time::TZ_NONE, NULL));
+        st->setTimestamp(param, y, mo, d, h, mi, s, t);
     }
 }
 
-void DataGeneratorFrame::setParam(IBPP::Statement st, int param,
+void DataGeneratorFrame::setParam(fr::IStatementPtr st, int param,
     GeneratorSettings* gs, int recNo)
 {
     if (gs->nullPercent > frRandom(100))
     {
-        st->SetNull(param);
+        st->setNull(param);
         return;
     }
 
     if (gs->valueType == GeneratorSettings::vtColumn)   // copy from column
     {
-        switch (st->ParameterType(param))
+        switch (st->getParameterType(param))
         {
-            case IBPP::sdBoolean: // Firebird v3
+            case fr::ColumnType::Boolean:
                 setFromOther<std::string>(st, param, gs, recNo);  break;
-            case IBPP::sdString:
+            case fr::ColumnType::Varchar:
                 setFromOther<std::string>(st, param, gs, recNo);  break;
-            case IBPP::sdSmallint:
-                setFromOther<int16_t>(st, param, gs, recNo);      break;
-            case IBPP::sdInteger:
+            case fr::ColumnType::Integer:
                 setFromOther<int32_t>(st, param, gs, recNo);      break;
-            case IBPP::sdLargeint:
+            case fr::ColumnType::BigInt:
                 setFromOther<int64_t>(st, param, gs, recNo);      break;
-            case IBPP::sdFloat:
+            case fr::ColumnType::Float:
                 setFromOther<float>(st, param, gs, recNo);        break;
-            case IBPP::sdDouble:
+            case fr::ColumnType::Double:
                 setFromOther<double>(st, param, gs, recNo);       break;
-            case IBPP::sdDate:
-                setFromOther<IBPP::Date>(st, param, gs, recNo);   break;
-            case IBPP::sdTime:
-            case IBPP::sdTimeTz:
-                setFromOther<IBPP::Time>(st, param, gs, recNo);   break;
-            case IBPP::sdTimestamp:
-            case IBPP::sdTimestampTz:
-                setFromOther<IBPP::Timestamp>(st, param, gs, recNo);  break;
-            case IBPP::sdBlob:
+            case fr::ColumnType::Date:
+                // Special handling needed if setFromOther is templates
+                break;
+            case fr::ColumnType::Time:
+            case fr::ColumnType::TimeTz:
+                break;
+            case fr::ColumnType::Timestamp:
+            case fr::ColumnType::TimestampTz:
+                break;
+            case fr::ColumnType::Blob:
                 throw FRError(_("Blob datatype not supported"));
-            case IBPP::sdArray:
-                throw FRError(_("Array datatype not supported"));
-            case IBPP::sdInt128:
-            case IBPP::sdDec16:
-            case IBPP::sdDec34:
+            default:
                 throw FRError(_("Datatype not supported"));
         };
         return;
@@ -1510,33 +1532,31 @@ void DataGeneratorFrame::setParam(IBPP::Statement st, int param,
 
     if (gs->valueType == GeneratorSettings::vtRange)
     {
-        switch (st->ParameterType(param))
+        switch (st->getParameterType(param))
         {
-            case IBPP::sdBoolean: // Firebird v3
+            case fr::ColumnType::Boolean:
                 setString(st, param, gs, recNo);          break;
-            case IBPP::sdString:
+            case fr::ColumnType::Varchar:
                 setString(st, param, gs, recNo);          break;
-            case IBPP::sdSmallint:
-                setNumber<int16_t>(st, param, gs, recNo); break;
-            case IBPP::sdInteger:
+            case fr::ColumnType::Integer:
                 setNumber<int32_t>(st, param, gs, recNo); break;
-            case IBPP::sdLargeint:
+            case fr::ColumnType::BigInt:
                 setNumber<int64_t>(st, param, gs, recNo); break;
-            case IBPP::sdFloat:
+            case fr::ColumnType::Float:
                 setNumber<float>  (st, param, gs, recNo); break;
-            case IBPP::sdDouble:
+            case fr::ColumnType::Double:
                 setNumber<double> (st, param, gs, recNo); break;
-            case IBPP::sdDate:
-            case IBPP::sdTime:
-            case IBPP::sdTimestamp:
+            case fr::ColumnType::Date:
+            case fr::ColumnType::Time:
+            case fr::ColumnType::TimeTz:
+            case fr::ColumnType::Timestamp:
+            case fr::ColumnType::TimestampTz:
                 setDatetime(st, param, gs, recNo);
                 break;
-            case IBPP::sdBlob:
+            case fr::ColumnType::Blob:
                 throw FRError(_("Blob datatype not supported"));
-            case IBPP::sdArray:
-                throw FRError(_("Array datatype not supported"));
             default:
-                st->SetNull(param);
+                st->setNull(param);
         };
     }
 
@@ -1548,12 +1568,11 @@ void DataGeneratorFrame::generateData(std::list<Table *>& order)
 {
     ProgressDialog pd(this, _("Generating data"), 2);
     pd.doShow();
-    pd.initProgress(_("Inserting into tables"), order.size());
+    pd.initProgress(_("Inserting into tables"), (int)order.size());
 
     // one big transaction (perhaps this should be configurable)
-    IBPP::Transaction tr =
-        IBPP::TransactionFactory(databaseM->getIBPPDatabase());
-    tr->Start();
+    fr::ITransactionPtr tr = databaseM->getDALDatabase()->createTransaction();
+    tr->start();
 
     for (std::list<Table *>::iterator it = order.begin();
         it != order.end(); ++it)
@@ -1596,21 +1615,20 @@ void DataGeneratorFrame::generateData(std::list<Table *>& order)
         if (first)  // no columns
             continue;
 
-        IBPP::Statement st =
-            IBPP::StatementFactory(databaseM->getIBPPDatabase(), tr);
-        st->Prepare(wx2std(ins + params + ")"));
+        fr::IStatementPtr st = databaseM->getDALDatabase()->createStatement(tr);
+        st->prepare(wx2std(ins + params + ")", databaseM->getCharsetConverter()));
 
         for (int i = 0; i < records; i++)
         {
             if (pd.isCanceled())
                 return;
             pd.stepProgress(1, 2);
-            for (int p = 0; p < st->Parameters(); ++p)
-                setParam(st, p+1, colSet[p], i);
-            st->Execute();
+            for (int p = 0; p < st->getParameterCount(); ++p)
+                setParam(st, p, colSet[p], i);
+            st->execute();
         }
     }
 
-    tr->Commit();
+    tr->commit();
 }
 

--- a/src/gui/DataGeneratorFrame.h
+++ b/src/gui/DataGeneratorFrame.h
@@ -59,9 +59,9 @@ protected:
     bool sortTables(std::list<Table *>& order);
     void generateData(std::list<Table *>& order);
 
-    void setParam( IBPP::Statement st, int param, GeneratorSettings* gs,
+    void setParam(fr::IStatementPtr st, int param, GeneratorSettings* gs,
         int recNo);
-    void setString(IBPP::Statement st, int param, GeneratorSettings* gs,
+    void setString(fr::IStatementPtr st, int param, GeneratorSettings* gs,
         int recNo);
 
     enum

--- a/src/gui/EditBlobDialog.cpp
+++ b/src/gui/EditBlobDialog.cpp
@@ -241,27 +241,27 @@ END_EVENT_TABLE()
 class FRInputBlobStream : public wxInputStream
 {
     public:
-        FRInputBlobStream(IBPP::Blob blob);
+        FRInputBlobStream(fr::IBlobPtr blob);
         virtual ~FRInputBlobStream();
         virtual size_t GetSize() const;
     protected:
         virtual size_t OnSysRead(void *buffer, size_t size);          
     private:
-        IBPP::Blob blobM;
+        fr::IBlobPtr blobM;
         int sizeM;
 };
 
 class FROutputBlobStream : public wxOutputStream
 {
     public:
-        FROutputBlobStream(IBPP::Blob blob);
+        FROutputBlobStream(fr::IBlobPtr blob);
         virtual ~FROutputBlobStream();
         
         virtual bool Close();
     protected:
         virtual size_t OnSysWrite(const void *buffer, size_t bufsize);
     private:
-        IBPP::Blob blobM;
+        fr::IBlobPtr blobM;
 };
 
 
@@ -392,8 +392,10 @@ EditBlobDialog::EditBlobDialog(wxWindow* parent, wxMBConv* converterM)
     rowM = 0;
     colM = 0;
     blobM = 0;
+    blobDALM = nullptr;
     loadingM = false;
     statementM = 0;
+    statementDALM = nullptr;
     readonlyM = false;
 
     this->converterM = converterM;
@@ -531,13 +533,14 @@ bool EditBlobDialog::setBlob(DataGrid* dg, DataGridTable* dgt,
 {
     // cancel load progress or wait for save progress
     progressCancel();
-    
+
     // Save last blob value if modified
     if (saveOldValue)
         saveBlob();
     dataGridTableM = dgt;
     dataGridM = dg;
     statementM = st;
+    statementDALM = nullptr;
     rowM = row;
     colM = col;
     readonlyM = dataGridTableM->isReadonlyColumn(colM);
@@ -545,9 +548,37 @@ bool EditBlobDialog::setBlob(DataGrid* dg, DataGridTable* dgt,
     // generator blob fieldname
     wxString tableName = dgt->getTableName();
     wxString fieldName = dg->GetColLabelValue(dg->GetGridCursorCol());
-    fieldNameM  = tableName + "." + fieldName;
+    fieldNameM = tableName + "." + fieldName;
 
-    dialogCaptionM = wxString::Format(_("Edit BLOB: %s #%i"), fieldNameM.c_str(), rowM+1);
+    dialogCaptionM = wxString::Format(_("Edit BLOB: %s #%i"), fieldNameM.c_str(), rowM + 1);
+    SetTitle(dialogCaptionM);
+
+    return loadBlob();
+}
+
+bool EditBlobDialog::setBlob(DataGrid* dg, DataGridTable* dgt,
+    fr::IStatementPtr st, unsigned row, unsigned col, bool saveOldValue)
+{
+    // cancel load progress or wait for save progress
+    progressCancel();
+
+    // Save last blob value if modified
+    if (saveOldValue)
+        saveBlob();
+    dataGridTableM = dgt;
+    dataGridM = dg;
+    statementM = nullptr;
+    statementDALM = st;
+    rowM = row;
+    colM = col;
+    readonlyM = dataGridTableM->isReadonlyColumn(colM);
+
+    // generator blob fieldname
+    wxString tableName = dgt->getTableName();
+    wxString fieldName = dg->GetColLabelValue(dg->GetGridCursorCol());
+    fieldNameM = tableName + "." + fieldName;
+
+    dialogCaptionM = wxString::Format(_("Edit BLOB: %s #%i"), fieldNameM.c_str(), rowM + 1);
     SetTitle(dialogCaptionM);
 
     return loadBlob();
@@ -570,22 +601,18 @@ bool EditBlobDialog::loadBlob()
     if (isBlob)
     {
         // Loading BLOB into Editor
-        IBPP::Blob* tmpBlob = dataGridTableM->getBlob(rowM, colM, false);
-        if (tmpBlob != 0)
-            blobM = *tmpBlob;
-        else
-            blobM = 0;
+        blobDALM = dataGridTableM->getBlob(rowM, colM, false);
 
-        FRInputBlobStream inpblob(blobM);
+        FRInputBlobStream inpblob(blobDALM);
 
         if (!isTextual)
         {
-            res = loadFromStreamAsBinary(inpblob, blobM == 0, _("Loading BLOB into editor."));
+            res = loadFromStreamAsBinary(inpblob, !blobDALM, _("Loading BLOB into editor."));
             editorModeM = binary;
         }
         else
         {
-            res = loadFromStreamAsText(inpblob, blobM == 0, _("Loading BLOB into editor."));
+            res = loadFromStreamAsText(inpblob, !blobDALM, _("Loading BLOB into editor."));
             editorModeM = text;
         }
 
@@ -605,6 +632,7 @@ bool EditBlobDialog::loadBlob()
     }
     else
     {
+        blobDALM = nullptr;
         blobM = 0;
         notebookAddPageById(noData);
         notebookRemovePageById(binary);
@@ -1005,23 +1033,22 @@ void EditBlobDialog::saveBlob()
 
         if (cacheIsNullM)
         {
-
-            b.blob = 0;
+            b.blob = nullptr;
         }
         else
         {
             wxMemoryInputStream inBuf(*cacheM);
 
             inBuf.Read((void*)buffer, 32767);
-            int bufLen = inBuf.LastRead();
-            b.blob->Create();
+            int bufLen = (int)inBuf.LastRead();
+            b.blob->create();
             while ((bufLen > 0) && (!progress->isCanceled()))
             {
-                b.blob->Write(buffer, bufLen);
+                b.blob->write(buffer, bufLen);
                 inBuf.Read((void*)buffer, 32767);
-                bufLen = inBuf.LastRead();
+                bufLen = (int)inBuf.LastRead();
             }
-            b.blob->Close();
+            b.blob->close();
         }
 
         ok = !progress->isCanceled();
@@ -1036,30 +1063,22 @@ void EditBlobDialog::saveBlob()
         bs.Close();
 
         if (isNull)
-            b.blob = 0;
+            b.blob = nullptr;
     }
 
     if (!ok)
         return;
 
-    if (b.blob == 0)
+    if (!b.blob)
         dataGridTableM->setValueToNull(b.row, b.col);
     else
     {
         dataGridTableM->setBlob(b);
     }
-    blobM = b.blob;
+    blobDALM = b.blob;
+    blobM = 0; // Clear IBPP blob if any
 
     // update datagrid to force an update (in GUI) of the changed blob-value
-    // NOTE: There are two reasons to call it
-    // 1) The data grid has to be updated to show the new blob value
-    // 2) There will be a error if user changes to another blob and
-    //    then again to the same. If the blob is selected again the
-    //    cell will be updated and opens the blob. This will happen
-    //    while the cancel-dialog in loadBlob is shown. (wxYieldIfNeeded)
-    //    At this moment the blob is already opend by loadBlob and
-    //    the IBPP::LocicalException - blob already open will occur.
-    // amaier/2009-07-19
     dataGridM->refreshAndInvalidateAttributes();
 
     cacheDelete();
@@ -1342,15 +1361,14 @@ END_EVENT_TABLE()
 
 // Helper-Class for streaming into blob / buffer
 // frInputBlobStream
-FRInputBlobStream::FRInputBlobStream(IBPP::Blob blob)
+FRInputBlobStream::FRInputBlobStream(fr::IBlobPtr blob)
     :wxInputStream()
 {
     blobM = blob;
-    if (blobM != 0)
+    if (blobM)
     {
-        blobM->Close();
-        blobM->Open();
-        blobM->Info(&sizeM, 0, 0);
+        blobM->open();
+        sizeM = (int)blobM->getLength();
     }
     else
         sizeM = 0;
@@ -1358,30 +1376,30 @@ FRInputBlobStream::FRInputBlobStream(IBPP::Blob blob)
 
 FRInputBlobStream::~FRInputBlobStream()
 {
-    if (blobM != 0)
-        blobM->Close();
+    if (blobM)
+        blobM->close();
 }
 
 size_t FRInputBlobStream::OnSysRead(void* buffer, size_t size)
 {
-    if ((blobM != 0) && (sizeM > 0))
-        return blobM->Read(buffer, size);
+    if (blobM && (sizeM > 0))
+        return (size_t)blobM->read(buffer, (int)size);
     else
         return 0;
 }
 
 size_t FRInputBlobStream::GetSize() const
 {
-    return sizeM;
+    return (size_t)sizeM;
 }
 
 // Helper-Class for streaming into blob / buffer
 // frOutputBlobStream
-FROutputBlobStream::FROutputBlobStream(IBPP::Blob blob)
+FROutputBlobStream::FROutputBlobStream(fr::IBlobPtr blob)
     :wxOutputStream()
 {
     blobM = blob;
-    blobM->Create();
+    blobM->create();
 }
 
 FROutputBlobStream::~FROutputBlobStream()
@@ -1394,14 +1412,14 @@ size_t FROutputBlobStream::OnSysWrite(const void* buffer, size_t bufsize)
     if (bufsize == 0)
         return 0;
 
-    blobM->Write(buffer, bufsize);
+    blobM->write(buffer, (int)bufsize);
     return bufsize;
 }
 
 bool FROutputBlobStream::Close()
 {
-    if (blobM != 0)
-        blobM->Close();
+    if (blobM)
+        blobM->close();
     return true;
 }
 

--- a/src/gui/EditBlobDialog.h
+++ b/src/gui/EditBlobDialog.h
@@ -49,14 +49,17 @@ public:
     // close without saving (for rollback-transaction)
     void closeDontSave(); 
     // DataGrid is needed to update a blob-cell due to blob is saved
-    bool setBlob(DataGrid* dg, DataGridTable* dgt, 
+    bool setBlob(DataGrid* dg, DataGridTable* dgt,
         IBPP::Statement* st, unsigned row, unsigned col, bool saveOldValue = true);
+    bool setBlob(DataGrid* dg, DataGridTable* dgt,
+        fr::IStatementPtr st, unsigned row, unsigned col, bool saveOldValue = true);
 private:
     enum EditorMode { noData = wxID_HIGHEST+1, 
                       binary = wxID_HIGHEST+2, 
                       text = wxID_HIGHEST+3 };
 
     IBPP::Blob blobM;
+    fr::IBlobPtr blobDALM;
     DataGridTable* dataGridTableM;
     DataGrid* dataGridM;
     wxString dialogCaptionM;
@@ -65,7 +68,8 @@ private:
     unsigned colM;
     unsigned rowM;
     bool runningM;
-    IBPP::Statement* statementM; 
+    IBPP::Statement* statementM;
+    fr::IStatementPtr statementDALM;
     wxMBConv* converterM;  //TODO: if possible, use directly from the database object
 
     std::set<EditorMode> dataValidM;

--- a/src/gui/ExecuteSqlFrame.cpp
+++ b/src/gui/ExecuteSqlFrame.cpp
@@ -564,9 +564,9 @@ ExecuteSqlFrame::ExecuteSqlFrame(wxWindow* WXUNUSED(parent), int id,
     if (db->getIsVolative())
         prepareVolatileDatabase();
 
-    transactionIsolationLevelM = static_cast<IBPP::TIL>(config().get("transactionIsolationLevel", 0));
-    transactionLockResolutionM = config().get("transactionLockResolution", true) ? IBPP::lrWait : IBPP::lrNoWait;
-    transactionAccessModeM = config().get("transactionAccessMode", false) ? IBPP::amRead : IBPP::amWrite;
+    transactionIsolationLevelM = static_cast<fr::TransactionIsolationLevel>(config().get("transactionIsolationLevel", 0));
+    transactionLockResolutionM = config().get("transactionLockResolution", true) ? fr::TransactionLockResolution::Wait : fr::TransactionLockResolution::NoWait;
+    transactionAccessModeM = config().get("transactionAccessMode", false) ? fr::TransactionAccessMode::Read : fr::TransactionAccessMode::Write;
     showStatisticsM = config().get("SQLEditorShowStats", true);
     highlightWordText = config().get("highlightWordText", true);
 
@@ -635,16 +635,16 @@ Database* ExecuteSqlFrame::getDatabase() const
 
 bool ExecuteSqlFrame::isTransactionStarted()
 {
-    if (transactionM == 0)
+    if (transactionM == nullptr)
         return false;
     try
     {
-        return transactionM->Started();
+        return transactionM->isActive();
     }
-    catch (IBPP::LogicException&)
+    catch (std::exception&)
     {
-        transactionM = 0;
-        statementM = 0;
+        transactionM = nullptr;
+        statementM = nullptr;
         inTransaction(false);
         executedStatementsM.clear();
         return false;
@@ -2419,19 +2419,17 @@ void ExecuteSqlFrame::OnMenuUpdateWhenExecutePossible(wxUpdateUIEvent& event)
     event.Enable(!closeWhenTransactionDoneM);
 }
 
-void ExecuteSqlFrame::compareCounts(IBPP::DatabaseCounts& one,
-    IBPP::DatabaseCounts& two)
+void ExecuteSqlFrame::compareCounts(std::map<int, fr::CountInfo>& one,
+    std::map<int, fr::CountInfo>& two)
 {
-    for (IBPP::DatabaseCounts::iterator it = two.begin(); it != two.end();
-        ++it)
+    for (auto const& [relId, r1] : two)
     {
         wxString str_log;
-        IBPP::DatabaseCounts::iterator i2 = one.find((*it).first);
-        IBPP::CountInfo c;
-        IBPP::CountInfo& r1 = (*it).second;
-        IBPP::CountInfo& r2 = c;
+        auto i2 = one.find(relId);
+        fr::CountInfo r2;
         if (i2 != one.end())
-            r2 = (*i2).second;
+            r2 = i2->second;
+
         if (r1.inserts > r2.inserts)
             str_log += wxString::Format(_("%d inserts. "), r1.inserts - r2.inserts);
         if (r1.updates > r2.updates)
@@ -2447,25 +2445,22 @@ void ExecuteSqlFrame::compareCounts(IBPP::DatabaseCounts& one,
             wxString relName;
             try
             {
-                IBPP::Statement st = IBPP::StatementFactory(
-                    databaseM->getIBPPDatabase(), transactionM);
-                st->Prepare(
+                fr::IStatementPtr st = databaseM->getDALDatabase()->createStatement(transactionM);
+                st->prepare(
                     "select rdb$relation_name "
                     "from rdb$relations where rdb$relation_id = ?");
-                st->Set(1, (*it).first);
-                st->Execute();
-                if (st->Fetch())
+                st->setInt32(0, relId);
+                st->execute();
+                if (st->fetch())
                 {
-                    std::string s;
-                    st->Get(1, s);
-                    relName = std2wxIdentifier(s, databaseM->getCharsetConverter());
+                    relName = std2wxIdentifier(st->getString(0), databaseM->getCharsetConverter());
                 }
             }
             catch (...)
             {
             }
             if (relName.IsEmpty())
-                relName.Format(_("Relation #%d"), (*it).first);
+                relName.Format(_("Relation #%d"), relId);
             log(relName + ": " + str_log, ttSql);
         }
     }
@@ -2563,104 +2558,92 @@ bool ExecuteSqlFrame::execute(wxString sql, const wxString& terminator,
         {
             log(_("Starting transaction..."));
 
-            // fix the IBPP::LogicException "No Database is attached."
-            // which happens after a database reconnect
-            // (this action detaches the database from all its transactions)
-            if (transactionM != 0 && !isTransactionStarted())
+            if (transactionM != nullptr && !isTransactionStarted())
             {
                 try
                 {
-                    transactionM->Start();
+                    transactionM->start();
                 }
-                catch (IBPP::LogicException&)
+                catch (...)
                 {
-                    transactionM = 0;
+                    transactionM = nullptr;
                 }
             }
 
-            if (transactionM == 0)
+            if (transactionM == nullptr)
             {
-                transactionM = IBPP::TransactionFactory(
-                    databaseM->getIBPPDatabase(), transactionAccessModeM,
-                    transactionIsolationLevelM, transactionLockResolutionM);
+                transactionM = databaseM->getDALDatabase()->createTransaction();
+                transactionM->setAccessMode(transactionAccessModeM);
+                transactionM->setIsolationLevel(transactionIsolationLevelM);
+                transactionM->setLockResolution(transactionLockResolutionM);
             }
-            transactionM->Start();
+            transactionM->start();
             inTransaction(true);
 
-            grid_data->EnableEditing(transactionAccessModeM == IBPP::amWrite);
+            grid_data->EnableEditing(transactionAccessModeM == fr::TransactionAccessMode::Write);
         }
 
         int fetch1 = 0, mark1 = 0, read1 = 0, write1 = 0, ins1 = 0, upd1 = 0,
             del1 = 0, ridx1 = 0, rseq1 = 0, mem1 = 0;
         int fetch2, mark2, read2, write2, ins2, upd2, del2, ridx2, rseq2, mem2;
-        IBPP::DatabaseCounts counts1, counts2;
+        std::map<int, fr::CountInfo> counts1, counts2;
         bool doShowStats = showStatisticsM;
         if (!prepareOnly && doShowStats)
         {
-            databaseM->getIBPPDatabase()->
-                Statistics(&fetch1, &mark1, &read1, &write1, &mem1);
-            databaseM->getIBPPDatabase()->
-                Counts(&ins1, &upd1, &del1, &ridx1, &rseq1);
-            databaseM->getIBPPDatabase()->DetailedCounts(counts1);
+            databaseM->getDALDatabase()->getStatistics(&fetch1, &mark1, &read1, &write1, &mem1);
+            databaseM->getDALDatabase()->getCounts(&ins1, &upd1, &del1, &ridx1, &rseq1);
+            databaseM->getDALDatabase()->getDetailedCounts(counts1);
         }
         grid_data->ClearGrid(); // statement object will be invalidated, so clear the grid
-        statementM = IBPP::StatementFactory(databaseM->getIBPPDatabase(), transactionM);
+        statementM = databaseM->getDALDatabase()->createStatement(transactionM);
         log(_("Preparing statement: ") + sql, ttSql);
         sae.scroll();
         {
             wxStopWatch sw;
-            statementM->Prepare(wx2std(sql, databaseM->getCharsetConverter()));
+            statementM->prepare(wx2std(sql, databaseM->getCharsetConverter()));
             log(wxString::Format(_("Statement prepared (elapsed time: %s)."),
                 millisToTimeString(sw.Time()).c_str()));
         }
 
-        // we don't check IBPP::Select since Firebird 2.0 has a new feature
-        // INSERT ... RETURNING which isn't detected as stSelect by IBPP
         bool hasColumns = false;
         try
         {
-            int cols = statementM->Columns();
+            int cols = statementM->getColumnCount();
             hasColumns = cols > 0;
             if (doShowStats)
             {
-                for (int i = 1; i <= cols; i++)
+                for (int i = 0; i < cols; i++)
                 {
-                    wxString tablename(std2wxIdentifier(statementM->ColumnTable(i),
+                    wxString tablename(std2wxIdentifier(statementM->getColumnTable(i),
                         databaseM->getCharsetConverter()));
-                    wxString colname(std2wxIdentifier(statementM->ColumnName(i),
+                    wxString colname(std2wxIdentifier(statementM->getColumnName(i),
                         databaseM->getCharsetConverter()));
-                    wxString aliasname(std2wxIdentifier(statementM->ColumnAlias(i),
+                    wxString aliasname(std2wxIdentifier(statementM->getColumnAlias(i),
                         databaseM->getCharsetConverter()));
-                    log(wxString::Format(_("Field #%02d: %s.%s Alias:%s Type:%s sqlype: %d subtype: %d len: %d scale: %d"),
-                        i, tablename.c_str(), colname.c_str(), aliasname.c_str(),
-                        IBPPtype2string(
+                    log(wxString::Format(_("Field #%02d: %s.%s Alias:%s Type:%s len: %d scale: %d"),
+                        i + 1, tablename.c_str(), colname.c_str(), aliasname.c_str(),
+                        DALtype2string(
                             databaseM,
-                            statementM->ColumnType(i),
-                            statementM->ColumnSubtype(i),
-                            statementM->ColumnSize(i),
-                            statementM->ColumnScale(i)).c_str(),
-                            statementM->ColumnSQLType(i),
-                            statementM->ColumnSubtype(i),
-                            statementM->ColumnSize(i),
-                            statementM->ColumnScale(i)
+                            statementM->getColumnType(i),
+                            statementM->getColumnSubtype(i),
+                            statementM->getColumnSize(i),
+                            statementM->getColumnScale(i)).c_str(),
+                            statementM->getColumnSize(i),
+                            statementM->getColumnScale(i)
                         ), ttSql);
                 }
             }
         }
-        catch(IBPP::Exception&)    // reading column info might fail,
+        catch(std::exception&)    // reading column info might fail,
         {                          // but we still want to show the plan
         }                          // so we have separate exception handlers
 
-        // for some statements (DDL) it is never available
-        // for INSERTs, it is available sometimes (insert into ... select ... )
-        // but if it not, IBPP throws an exception
         try
         {
-            std::string plan;
-            statementM->Plan(plan);
+            std::string plan = statementM->getPlan();
             log(wxString(plan.c_str(), *databaseM->getCharsetConverter()));
         }
-        catch(IBPP::Exception&)
+        catch(std::exception&)
         {
             log(_("Plan not available."));
         }
@@ -2668,9 +2651,9 @@ bool ExecuteSqlFrame::execute(wxString sql, const wxString& terminator,
         if (prepareOnly)
             return true;
 
-        log(wxString::Format(_("Parameters: %zu"), statementM->ParametersByName().size() ));
+        log(wxString::Format(_("Parameters: %d"), statementM->getParameterCount() ));
         //Define parameters here:
-        if (statementM->ParametersByName().size() >0)
+        if (statementM->getParameterCount() > 0)
         {
             //Insert parameters here:
             InsertParametersDialog* id = new InsertParametersDialog(this, statementM,
@@ -2685,23 +2668,23 @@ bool ExecuteSqlFrame::execute(wxString sql, const wxString& terminator,
         sae.scroll();
         {
             wxStopWatch sw;
-            statementM->Execute();
+            statementM->execute();
             log(wxString::Format(_("Statement executed (elapsed time: %s)."),
                 millisToTimeString(sw.Time()).c_str()));
         }
-        IBPP::STT type = statementM->Type();
+        fr::StatementType type = statementM->getType();
         if (hasColumns)            // for select statements: show data
         {
-            grid_data->fetchData(transactionAccessModeM == IBPP::amRead);
+            grid_data->fetchData(transactionAccessModeM == fr::TransactionAccessMode::Read);
             setViewMode(vmGrid);
         }
 
         if (doShowStats)
         {
-            databaseM->getIBPPDatabase()->Statistics(
+            databaseM->getDALDatabase()->getStatistics(
                 &fetch2, &mark2, &read2, &write2, &mem2);
-            databaseM->getIBPPDatabase()->
-                Counts(&ins2, &upd2, &del2, &ridx2, &rseq2);
+            databaseM->getDALDatabase()->getCounts(
+                &ins2, &upd2, &del2, &ridx2, &rseq2);
             log(wxString::Format(
                 _("%d fetches, %d marks, %d reads, %d writes."),
                 fetch2-fetch1, mark2-mark1, read2-read1, write2-write1));
@@ -2709,46 +2692,47 @@ bool ExecuteSqlFrame::execute(wxString sql, const wxString& terminator,
                 _("%d inserts, %d updates, %d deletes, %d index, %d seq."),
                 ins2-ins1, upd2-upd1, del2-del1, ridx2-ridx1, rseq2-rseq1));
             log(wxString::Format(_("Delta memory: %d bytes."), mem2-mem1));
-            databaseM->getIBPPDatabase()->DetailedCounts(counts2);
+            databaseM->getDALDatabase()->getDetailedCounts(counts2);
             compareCounts(counts1, counts2);
         }
 
-        if (type != IBPP::stSelect) // for other statements: show rows affected
+        if (type != fr::StatementType::Select) // for other statements: show rows affected
         {   // left trim
             wxString::size_type p = sql.find_first_not_of(" \n\t\r");
             if (p != wxString::npos && p > 0)
                 sql.erase(0, p);
-            if (type == IBPP::stInsert || type == IBPP::stDelete
-                || type == IBPP::stExecProcedure || type == IBPP::stUpdate)
+            if (type == fr::StatementType::Insert || type == fr::StatementType::Delete
+                || type == fr::StatementType::ExecProcedure || type == fr::StatementType::Update)
             {
                 // INSERT INTO..RETURNING and EXECUTE PROCEDURE may throw
                 // when they return a single record
                 try
                 {
                     wxString addon;
-                    if (statementM->AffectedRows() % 10 != 1)
+                    int affectedRows = statementM->getAffectedRows();
+                    if (affectedRows % 10 != 1)
                         addon = "s";
                     wxString s = wxString::Format(_("%d row%s affected directly."),
-                        statementM->AffectedRows(), addon.c_str());
+                        affectedRows, addon.c_str());
                     log("" + s);
                     statusbar_1->SetStatusText(s, 1);
                 }
-                catch (IBPP::Exception&)
+                catch (std::exception&)
                 {
                 }
             }
             if (stm.isDDL())
-                type = IBPP::stDDL;
+                type = fr::StatementType::DDL;
             executedStatementsM.push_back(stm);
             setViewMode(vmEditor);
-            if (type == IBPP::stDDL && autoCommitM)
+            if (type == fr::StatementType::DDL && autoCommitM)
             {
                 if (!commitTransaction())
                     retval = false;
             }
         }
     }
-    catch(IBPP::Exception& e)
+    catch(std::exception& e)
     {
         splitScreen();
         wxString msg(e.what(),
@@ -2791,17 +2775,17 @@ void ExecuteSqlFrame::splitScreen()
 void ExecuteSqlFrame::OnMenuTransactionIsolationLevel(wxCommandEvent& event)
 {
     if (event.GetId() == Cmds::Query_TransactionConcurrency)
-        transactionIsolationLevelM = IBPP::ilConcurrency;
+        transactionIsolationLevelM = fr::TransactionIsolationLevel::Concurrency;
     else if (event.GetId() == Cmds::Query_TransactionConsistency)
-        transactionIsolationLevelM = IBPP::ilConsistency;
+        transactionIsolationLevelM = fr::TransactionIsolationLevel::Consistency;
     else if (event.GetId() == Cmds::Query_TransactionReadCommitted)
-        transactionIsolationLevelM = IBPP::ilReadCommitted;
+        transactionIsolationLevelM = fr::TransactionIsolationLevel::ReadCommitted;
     else if (event.GetId() == Cmds::Query_TransactionReadDirty)
-        transactionIsolationLevelM = IBPP::ilReadDirty;
+        transactionIsolationLevelM = fr::TransactionIsolationLevel::ReadDirty;
 
     wxCHECK_RET(!isTransactionStarted(),
         "Can't change transaction isolation level while started");
-    transactionM = 0;
+    transactionM = nullptr;
 }
 
 void ExecuteSqlFrame::OnMenuUpdateTransactionIsolationLevel(
@@ -2809,45 +2793,45 @@ void ExecuteSqlFrame::OnMenuUpdateTransactionIsolationLevel(
 {
     event.Enable(!isTransactionStarted());
     if (event.GetId() == Cmds::Query_TransactionConcurrency)
-        event.Check(transactionIsolationLevelM == IBPP::ilConcurrency);
+        event.Check(transactionIsolationLevelM == fr::TransactionIsolationLevel::Concurrency);
     else if (event.GetId() == Cmds::Query_TransactionConsistency)
-        event.Check(transactionIsolationLevelM == IBPP::ilConsistency);
+        event.Check(transactionIsolationLevelM == fr::TransactionIsolationLevel::Consistency);
     else if (event.GetId() == Cmds::Query_TransactionReadCommitted)
-        event.Check(transactionIsolationLevelM == IBPP::ilReadCommitted);
+        event.Check(transactionIsolationLevelM == fr::TransactionIsolationLevel::ReadCommitted);
     else if (event.GetId() == Cmds::Query_TransactionReadDirty)
-        event.Check(transactionIsolationLevelM == IBPP::ilReadDirty);
+        event.Check(transactionIsolationLevelM == fr::TransactionIsolationLevel::ReadDirty);
 }
 
 void ExecuteSqlFrame::OnMenuTransactionLockResolution(wxCommandEvent& event)
 {
     transactionLockResolutionM =
-        event.IsChecked() ? IBPP::lrWait : IBPP::lrNoWait;
+        event.IsChecked() ? fr::TransactionLockResolution::Wait : fr::TransactionLockResolution::NoWait;
 
     wxCHECK_RET(!isTransactionStarted(),
         "Can't change transaction lock resolution while started");
-    transactionM = 0;
+    transactionM = nullptr;
 }
 
 void ExecuteSqlFrame::OnMenuUpdateTransactionLockResolution(
     wxUpdateUIEvent& event)
 {
     event.Enable(!isTransactionStarted());
-    event.Check(transactionLockResolutionM == IBPP::lrWait);
+    event.Check(transactionLockResolutionM == fr::TransactionLockResolution::Wait);
 }
 
 void ExecuteSqlFrame::OnMenuTransactionReadOnly(wxCommandEvent& event)
 {
-    transactionAccessModeM = event.IsChecked() ? IBPP::amRead : IBPP::amWrite;
+    transactionAccessModeM = event.IsChecked() ? fr::TransactionAccessMode::Read : fr::TransactionAccessMode::Write;
 
     wxCHECK_RET(!isTransactionStarted(),
         "Can't change transaction access mode while started");
-    transactionM = 0;
+    transactionM = nullptr;
 }
 
 void ExecuteSqlFrame::OnMenuUpdateTransactionReadOnly(wxUpdateUIEvent& event)
 {
     event.Enable(!isTransactionStarted());
-    event.Check(transactionAccessModeM == IBPP::amRead);
+    event.Check(transactionAccessModeM == fr::TransactionAccessMode::Read);
 }
 
 void ExecuteSqlFrame::OnMenuCommit(wxCommandEvent& WXUNUSED(event))
@@ -2927,19 +2911,10 @@ bool ExecuteSqlFrame::commitTransaction()
             return true;
         }
     }
-    catch (IBPP::LogicException&)
-    {
-        transactionM = 0;
-        statementM = 0;
-        inTransaction(false);
-        executedStatementsM.clear();
-        return true;
-    }
-    catch (IBPP::Exception &e)
+    catch (const std::exception& e)
     {
         splitScreen();
-        log(wxString(e.what(), *databaseM->getCharsetConverter()),
-            ttError);
+        log(wxString(e.what(), *databaseM->getCharsetConverter()), ttError);
         return false;
     }
     catch (std::exception &se)
@@ -3001,19 +2976,10 @@ bool ExecuteSqlFrame::rollbackTransaction()
             return true;
         }
     }
-    catch (IBPP::LogicException&)
-    {
-        transactionM = 0;
-        statementM = 0;
-        inTransaction(false);
-        executedStatementsM.clear();
-        return true;
-    }
-    catch (IBPP::Exception &e)
+    catch (const std::exception& e)
     {
         splitScreen();
-        log(wxString(e.what(), *databaseM->getCharsetConverter()),
-            ttError);
+        log(wxString(e.what(), *databaseM->getCharsetConverter()), ttError);
         return false;
     }
     catch (...)

--- a/src/gui/ExecuteSqlFrame.h
+++ b/src/gui/ExecuteSqlFrame.h
@@ -105,7 +105,7 @@ private:
     wxFileName filenameM;
     wxDateTime filenameModificationTimeM;
 
-    void compareCounts(IBPP::DatabaseCounts& one, IBPP::DatabaseCounts& two);
+    void compareCounts(std::map<int, fr::CountInfo>& one, std::map<int, fr::CountInfo>& two);
 
     void showProperties(wxString objectName);
 
@@ -130,12 +130,12 @@ private:
     bool inParseStatementsM = false; // reentrancy guard for parseStatements yields
     bool autoCommitM;
     bool inTransactionM;
-    IBPP::Transaction transactionM;
-    IBPP::Statement statementM;
+    fr::ITransactionPtr transactionM;
+    fr::IStatementPtr statementM;
     bool isTransactionStarted();
-    IBPP::TIL transactionIsolationLevelM;
-    IBPP::TLR transactionLockResolutionM;
-    IBPP::TAM transactionAccessModeM;
+    fr::TransactionIsolationLevel transactionIsolationLevelM;
+    fr::TransactionLockResolution transactionLockResolutionM;
+    fr::TransactionAccessMode transactionAccessModeM;
     bool showStatisticsM;
     void inTransaction(bool started);       // changes controls (enable/disable)
     bool commitTransaction();

--- a/src/gui/InsertDialog.cpp
+++ b/src/gui/InsertDialog.cpp
@@ -153,10 +153,23 @@ public:
 InsertDialog::InsertDialog(wxWindow* parent, const wxString& tableName,
     DataGridTable *gridTable, IBPP::Statement& st, Database *db)
     :BaseDialog(parent, -1, wxEmptyString), tableNameM(tableName), bufferM(0),
-    gridTableM(gridTable), statementM(st), databaseM(db)
+    gridTableM(gridTable), statementM(st), statementDALM(nullptr), databaseM(db)
+{
+    createGrid(gridTable);
+}
+
+InsertDialog::InsertDialog(wxWindow* parent, const wxString& tableName,
+    DataGridTable *gridTable, fr::IStatementPtr st, Database *db)
+    :BaseDialog(parent, -1, wxEmptyString), tableNameM(tableName), bufferM(0),
+    gridTableM(gridTable), statementM(nullptr), statementDALM(st), databaseM(db)
+{
+    createGrid(gridTable);
+}
+
+void InsertDialog::createGrid(DataGridTable *gridTable)
 {
     DataGridTable::FieldSet fields;
-    gridTable->getFields(tableName, fields);
+    gridTable->getFields(tableNameM, fields);
 
     // 500 should be reasonable for enough rows on the screen, but not too much
     gridM = new wxGrid(getControlsPanel(), ID_Grid, wxDefaultPosition,
@@ -452,37 +465,75 @@ void InsertDialog::preloadSpecialColumns()
     }
 
     // step 2: load those from the database
-    IBPP::Statement st1 = IBPP::StatementFactory(statementM->DatabasePtr(),
-        statementM->TransactionPtr());
-    if (!first) // we do need some data
+    if (statementDALM)
     {
-        sql += " FROM RDB$DATABASE";
-        st1->Prepare(wx2std(sql));
-        st1->Execute();
-        st1->Fetch();
-    }
+        fr::IStatementPtr st1 = databaseM->getDALDatabase()->createStatement(
+            statementDALM->getTransaction());
+        if (!first) // we do need some data
+        {
+            sql += " FROM RDB$DATABASE";
+            st1->prepare(wx2std(sql));
+            st1->execute();
+            st1->fetch();
+        }
 
-    // step 3: save values into buffer and edit controls
-    //         so that the next run doesn't reload generators
-    unsigned col = 1;
-    for (std::vector<InsertColumnInfo>::iterator it = columnsM.begin();
-        it != columnsM.end(); ++it)
+        // step 3: save values into buffer and edit controls
+        //         so that the next run doesn't reload generators
+        unsigned col = 1;
+        for (std::vector<InsertColumnInfo>::iterator it = columnsM.begin();
+            it != columnsM.end(); ++it)
+        {
+            InsertOption sel = getInsertOption(gridM, (*it).row);
+            if (!optionValueLoadedFromDatabase(sel))
+                continue;
+            bufferM->setFieldNA((*it).index, false);
+            bufferM->setFieldNull((*it).index, st1->isNull(col - 1));
+            if (!st1->isNull(col - 1))
+                (*it).columnDef->setValue(bufferM, col, st1, wxConvCurrent, databaseM);
+            ++col;
+            if (sel != ioGenerator)  // what follows is only for generators
+                continue;
+            gridM->SetCellValue((*it).row, 3,
+                (*it).columnDef->getAsString(bufferM, databaseM));
+            gridM->SetCellValue((*it).row, 2,
+                insertOptionStrings[ioRegular]);  // treat as regular value
+            updateControls((*it).row);
+        }
+    }
+    else
     {
-        InsertOption sel = getInsertOption(gridM, (*it).row);
-        if (!optionValueLoadedFromDatabase(sel))
-            continue;
-        bufferM->setFieldNA((*it).index, false);
-        bufferM->setFieldNull((*it).index, st1->IsNull(col));
-        if (!st1->IsNull(col))
-            (*it).columnDef->setValue(bufferM, col, st1, wxConvCurrent, databaseM);
-        ++col;
-        if (sel != ioGenerator)  // what follows is only for generators
-            continue;
-        gridM->SetCellValue((*it).row, 3,
-            (*it).columnDef->getAsString(bufferM, databaseM));
-        gridM->SetCellValue((*it).row, 2,
-            insertOptionStrings[ioRegular]);  // treat as regular value
-        updateControls((*it).row);
+        IBPP::Statement st1 = IBPP::StatementFactory(statementM->DatabasePtr(),
+            statementM->TransactionPtr());
+        if (!first) // we do need some data
+        {
+            sql += " FROM RDB$DATABASE";
+            st1->Prepare(wx2std(sql));
+            st1->Execute();
+            st1->Fetch();
+        }
+
+        // step 3: save values into buffer and edit controls
+        //         so that the next run doesn't reload generators
+        unsigned col = 1;
+        for (std::vector<InsertColumnInfo>::iterator it = columnsM.begin();
+            it != columnsM.end(); ++it)
+        {
+            InsertOption sel = getInsertOption(gridM, (*it).row);
+            if (!optionValueLoadedFromDatabase(sel))
+                continue;
+            bufferM->setFieldNA((*it).index, false);
+            bufferM->setFieldNull((*it).index, st1->IsNull(col));
+            if (!st1->IsNull(col))
+                (*it).columnDef->setValue(bufferM, col, st1, wxConvCurrent, databaseM);
+            ++col;
+            if (sel != ioGenerator)  // what follows is only for generators
+                continue;
+            gridM->SetCellValue((*it).row, 3,
+                (*it).columnDef->getAsString(bufferM, databaseM));
+            gridM->SetCellValue((*it).row, 2,
+                insertOptionStrings[ioRegular]);  // treat as regular value
+            updateControls((*it).row);
+        }
     }
 }
 
@@ -561,39 +612,79 @@ void InsertDialog::OnOkButtonClick(wxCommandEvent& WXUNUSED(event))
         }
     }
 
-    IBPP::Statement st1 = IBPP::StatementFactory(statementM->DatabasePtr(),
-        statementM->TransactionPtr());
     stm += val + ")";
-    st1->Prepare(wx2std(stm, databaseM->getCharsetConverter()));
 
-    // load blobs
-    int index = 1;
-    for (std::vector<InsertColumnInfo>::iterator it = columnsM.begin();
-        it != columnsM.end(); ++it)
+    if (statementDALM)
     {
-        if (getInsertOption(gridM, (*it).row) != ioFile)
-            continue;
-        wxFFile fl(gridM->GetCellValue((*it).row, 3), "rb");
-        if (!fl.IsOpened())
-            throw FRError(_("Cannot open BLOB file."));
-        IBPP::Blob b = IBPP::BlobFactory(st1->DatabasePtr(),
-            st1->TransactionPtr());
-        b->Create();
-        uint8_t buffer[32768];
-        while (!fl.Eof())
-        {
-            size_t len = fl.Read(buffer, 32767);    // slow when not 32k
-            if (len < 1)
-                break;
-            b->Write(buffer, len);
-        }
-        fl.Close();
-        b->Close();
-        st1->Set(index++, b);
-        bufferM->setBlob((*it).columnDef->getIndex(), b);
-    }
+        fr::IStatementPtr st1 = databaseM->getDALDatabase()->createStatement(
+            statementDALM->getTransaction());
+        st1->prepare(wx2std(stm, databaseM->getCharsetConverter()));
 
-    st1->Execute();
+        // load blobs
+        int index = 1;
+        for (std::vector<InsertColumnInfo>::iterator it = columnsM.begin();
+            it != columnsM.end(); ++it)
+        {
+            if (getInsertOption(gridM, (*it).row) != ioFile)
+                continue;
+            wxFFile fl(gridM->GetCellValue((*it).row, 3), "rb");
+            if (!fl.IsOpened())
+                throw FRError(_("Cannot open BLOB file."));
+
+            fr::IBlobPtr b = databaseM->getDALDatabase()->createBlob(
+                statementDALM->getTransaction());
+            b->create();
+            uint8_t buffer[32768];
+            while (!fl.Eof())
+            {
+                size_t len = fl.Read(buffer, 32767);
+                if (len < 1)
+                    break;
+                b->write(buffer, len);
+            }
+            fl.Close();
+            b->close();
+            st1->setBlob(index++ - 1, b);
+            bufferM->setBlob((*it).columnDef->getIndex(), b);
+        }
+
+        st1->execute();
+    }
+    else
+    {
+        IBPP::Statement st1 = IBPP::StatementFactory(statementM->DatabasePtr(),
+            statementM->TransactionPtr());
+        st1->Prepare(wx2std(stm, databaseM->getCharsetConverter()));
+
+        // load blobs
+        int index = 1;
+        for (std::vector<InsertColumnInfo>::iterator it = columnsM.begin();
+            it != columnsM.end(); ++it)
+        {
+            if (getInsertOption(gridM, (*it).row) != ioFile)
+                continue;
+            wxFFile fl(gridM->GetCellValue((*it).row, 3), "rb");
+            if (!fl.IsOpened())
+                throw FRError(_("Cannot open BLOB file."));
+            IBPP::Blob b = IBPP::BlobFactory(st1->DatabasePtr(),
+                st1->TransactionPtr());
+            b->Create();
+            uint8_t buffer[32768];
+            while (!fl.Eof())
+            {
+                size_t len = fl.Read(buffer, 32767);    // slow when not 32k
+                if (len < 1)
+                    break;
+                b->Write(buffer, len);
+            }
+            fl.Close();
+            b->Close();
+            st1->Set(index++, b);
+            bufferM->setBlob((*it).columnDef->getIndex(), b);
+        }
+
+        st1->Execute();
+    }
 
     // add buffer to the table and set internal buffer marker to zero
     // (to prevent deletion in destructor)

--- a/src/gui/InsertDialog.h
+++ b/src/gui/InsertDialog.h
@@ -56,6 +56,8 @@ class InsertDialog: public BaseDialog
 public:
     InsertDialog(wxWindow* parent, const wxString& tableName, DataGridTable *,
         IBPP::Statement& st, Database *db);
+    InsertDialog(wxWindow* parent, const wxString& tableName, DataGridTable *,
+        fr::IStatementPtr st, Database *db);
     virtual ~InsertDialog();
     void OnOkButtonClick(wxCommandEvent& event);
     void OnCancelButtonClick(wxCommandEvent& event);
@@ -71,7 +73,9 @@ private:
     Database *databaseM;
     void storeValues();
     void preloadSpecialColumns();
-    IBPP::Statement& statementM;
+    void createGrid(DataGridTable *gridTable);
+    IBPP::Statement statementM;
+    fr::IStatementPtr statementDALM;
     std::vector<InsertColumnInfo> columnsM;
     DataGridTable *gridTableM;
     InsertedGridRowBuffer *bufferM;

--- a/src/gui/InsertParametersDialog.cpp
+++ b/src/gui/InsertParametersDialog.cpp
@@ -169,10 +169,24 @@ public:
 //  it's better to merge both, in a single one parameter, and use Set(name, value)
 //  let IBPP set the values by itself
 InsertParametersDialog::InsertParametersDialog(wxWindow* parent, IBPP::Statement& st, Database *db, std::map<std::string, wxString>& pParameterSaveList, std::map<std::string, wxString>& pParameterSaveListOptionNull)
-    :BaseDialog(parent, -1, wxEmptyString), bufferM(0), statementM(st), databaseM(db), parameterSaveList(pParameterSaveList), parameterSaveListOptionNull(pParameterSaveListOptionNull)
+    :BaseDialog(parent, -1, wxEmptyString), bufferM(0), statementM(st), statementDALM(nullptr), databaseM(db), parameterSaveList(pParameterSaveList), parameterSaveListOptionNull(pParameterSaveListOptionNull)
 {
+    createGrid();
+}
 
-    int count = statementM->ParametersByName().size();
+InsertParametersDialog::InsertParametersDialog(wxWindow* parent, fr::IStatementPtr st, Database *db, std::map<std::string, wxString>& pParameterSaveList, std::map<std::string, wxString>& pParameterSaveListOptionNull)
+    :BaseDialog(parent, -1, wxEmptyString), bufferM(0), statementM(nullptr), statementDALM(st), databaseM(db), parameterSaveList(pParameterSaveList), parameterSaveListOptionNull(pParameterSaveListOptionNull)
+{
+    createGrid();
+}
+
+void InsertParametersDialog::createGrid()
+{
+    int count = 0;
+    if (statementDALM)
+        count = statementDALM->getParameterCount();
+    else
+        count = statementM->ParametersByName().size();
 
     // 500 should be reasonable for enough rows on the screen, but not too much
     gridM = new wxGrid(getControlsPanel(), ID_Grid, wxDefaultPosition,
@@ -189,7 +203,7 @@ InsertParametersDialog::InsertParametersDialog(wxWindow* parent, IBPP::Statement
         wxTRANSLATE("Special"),    wxTRANSLATE("Value") };
 
     bufferM = new InsertedGridRowBuffer(count);
-    for (unsigned u = 0; (int)u < count; u++)
+    for (unsigned u = 0; (int)u < (unsigned)count; u++)
         bufferM->setFieldNA(u, true);
 
     gridM->CreateGrid(count, sizeof(labels)/sizeof(wxString));
@@ -501,37 +515,75 @@ void InsertParametersDialog::preloadSpecialColumns()
     }
 
     // step 2: load those from the database
-    IBPP::Statement st1 = IBPP::StatementFactory(statementM->DatabasePtr(),
-        statementM->TransactionPtr());
-    if (!first) // we do need some data
+    if (statementDALM)
     {
-        sql += " FROM RDB$DATABASE";
-        st1->Prepare(wx2std(sql));
-        st1->Execute();
-        st1->Fetch();
-    }
+        fr::IStatementPtr st1 = databaseM->getDALDatabase()->createStatement(
+            statementDALM->getTransaction());
+        if (!first) // we do need some data
+        {
+            sql += " FROM RDB$DATABASE";
+            st1->prepare(wx2std(sql));
+            st1->execute();
+            st1->fetch();
+        }
 
-    // step 3: save values into buffer and edit controls
-    //         so that the next run doesn't reload generators
-    unsigned col = 1;
-    for (std::vector<InsertParametersColumnInfo>::iterator it = columnsM.begin();
-        it != columnsM.end(); ++it)
+        // step 3: save values into buffer and edit controls
+        //         so that the next run doesn't reload generators
+        unsigned col = 1;
+        for (std::vector<InsertParametersColumnInfo>::iterator it = columnsM.begin();
+            it != columnsM.end(); ++it)
+        {
+            InsertParametersOption sel = getInsertParametersOption(gridM, (*it).row);
+            if (!optionValueLoadedFromDatabase(sel))
+                continue;
+            bufferM->setFieldNA((*it).index, false);
+            bufferM->setFieldNull((*it).index, st1->isNull(col - 1));
+            if (!st1->isNull(col - 1))
+                (*it).columnDef->setValue(bufferM, col, st1, wxConvCurrent, databaseM);
+            ++col;
+            //if (sel != ioGenerator)  // what follows is only for generators
+                continue;
+            gridM->SetCellValue((*it).row, 3,
+                (*it).columnDef->getAsString(bufferM, databaseM));
+            gridM->SetCellValue((*it).row, 2,
+                insertParametersOptionStrings[ioRegular]);  // treat as regular value
+            updateControls((*it).row);
+        }
+    }
+    else
     {
-        InsertParametersOption sel = getInsertParametersOption(gridM, (*it).row);
-        if (!optionValueLoadedFromDatabase(sel))
-            continue;
-        bufferM->setFieldNA((*it).index, false);
-        bufferM->setFieldNull((*it).index, st1->IsNull(col));
-        if (!st1->IsNull(col))
-            (*it).columnDef->setValue(bufferM, col, st1, wxConvCurrent, databaseM);
-        ++col;
-        //if (sel != ioGenerator)  // what follows is only for generators
-            continue;
-        gridM->SetCellValue((*it).row, 3,
-            (*it).columnDef->getAsString(bufferM, databaseM));
-        gridM->SetCellValue((*it).row, 2,
-            insertParametersOptionStrings[ioRegular]);  // treat as regular value
-        updateControls((*it).row);
+        IBPP::Statement st1 = IBPP::StatementFactory(statementM->DatabasePtr(),
+            statementM->TransactionPtr());
+        if (!first) // we do need some data
+        {
+            sql += " FROM RDB$DATABASE";
+            st1->Prepare(wx2std(sql));
+            st1->Execute();
+            st1->Fetch();
+        }
+
+        // step 3: save values into buffer and edit controls
+        //         so that the next run doesn't reload generators
+        unsigned col = 1;
+        for (std::vector<InsertParametersColumnInfo>::iterator it = columnsM.begin();
+            it != columnsM.end(); ++it)
+        {
+            InsertParametersOption sel = getInsertParametersOption(gridM, (*it).row);
+            if (!optionValueLoadedFromDatabase(sel))
+                continue;
+            bufferM->setFieldNA((*it).index, false);
+            bufferM->setFieldNull((*it).index, st1->IsNull(col));
+            if (!st1->IsNull(col))
+                (*it).columnDef->setValue(bufferM, col, st1, wxConvCurrent, databaseM);
+            ++col;
+            //if (sel != ioGenerator)  // what follows is only for generators
+                continue;
+            gridM->SetCellValue((*it).row, 3,
+                (*it).columnDef->getAsString(bufferM, databaseM));
+            gridM->SetCellValue((*it).row, 2,
+                insertParametersOptionStrings[ioRegular]);  // treat as regular value
+            updateControls((*it).row);
+        }
     }
 }
 
@@ -576,7 +628,7 @@ void InsertParametersDialog::OnCancelButtonClick(wxCommandEvent& WXUNUSED(event)
 {
     Close();
 }
-void InsertParametersDialog::parseDate(int row, const wxString& source)
+void InsertParametersDialog::parseDate(int index, const wxString& source)
 {
     IBPP::Date idt;
     idt.Today();
@@ -600,9 +652,14 @@ void InsertParametersDialog::parseDate(int row, const wxString& source)
             throw FRError(_("Cannot parse date"));
         idt.SetDate(y, m, d);
     }
-    statementM->Set(row+1, idt);
+
+    if (statementDALM)
+        statementDALM->setDate(index, idt.Year(), idt.Month(), idt.Day());
+    else
+        statementM->Set(index + 1, idt);
 }
-void InsertParametersDialog::parseTime(int row, const wxString& source)
+
+void InsertParametersDialog::parseTime(int index, const wxString& source)
 {
     IBPP::Time itm;
     itm.Now();
@@ -618,10 +675,18 @@ void InsertParametersDialog::parseTime(int row, const wxString& source)
             throw FRError(_("Cannot parse time"));
         itm.SetTime(IBPP::Time::tmNone, hr, mn, sc, 10 * ms, IBPP::Time::TZ_NONE, NULL);
     }
-    statementM->Set(row+1, itm);
+
+    if (statementDALM)
+    {
+        int hr, mn, sc, ms;
+        itm.GetTime(hr, mn, sc, ms);
+        statementDALM->setTime(index, hr, mn, sc, ms);
+    }
+    else
+        statementM->Set(index + 1, itm);
 }
 
-void InsertParametersDialog::parseTimeStamp(int row, const wxString& source)
+void InsertParametersDialog::parseTimeStamp(int index, const wxString& source)
 {
 
     IBPP::Timestamp its;
@@ -655,7 +720,15 @@ void InsertParametersDialog::parseTimeStamp(int row, const wxString& source)
     }
 
     // all done, set the value
-    statementM->Set(row+1, its);
+    if (statementDALM)
+    {
+        int y, mo, d, hr, mi, s, ms;
+        its.GetDate(y, mo, d);
+        its.GetTime(hr, mi, s, ms);
+        statementDALM->setTimestamp(index, y, mo, d, hr, mi, s, ms);
+    }
+    else
+        statementM->Set(index + 1, its);
 }
 
 void InsertParametersDialog::OnOkButtonClick(wxCommandEvent& WXUNUSED(event))

--- a/src/gui/InsertParametersDialog.h
+++ b/src/gui/InsertParametersDialog.h
@@ -56,6 +56,7 @@ class InsertParametersDialog: public BaseDialog
 {
 public:
     InsertParametersDialog(wxWindow* parent, IBPP::Statement& st, Database *db, std::map<std::string, wxString>& pParameterSaveList, std::map<std::string, wxString>& pParameterSaveListOptionNull);
+    InsertParametersDialog(wxWindow* parent, fr::IStatementPtr st, Database *db, std::map<std::string, wxString>& pParameterSaveList, std::map<std::string, wxString>& pParameterSaveListOptionNull);
     virtual ~InsertParametersDialog();
     void OnOkButtonClick(wxCommandEvent& event);
     void OnCancelButtonClick(wxCommandEvent& event);
@@ -72,7 +73,9 @@ private:
     Database *databaseM;
     void storeValues();
     void preloadSpecialColumns();
-    IBPP::Statement& statementM;
+    void createGrid();
+    IBPP::Statement statementM;
+    fr::IStatementPtr statementDALM;
     std::vector<InsertParametersColumnInfo> columnsM;
     std::map<std::string, wxString>& parameterSaveList;
     std::map<std::string, wxString>& parameterSaveListOptionNull;
@@ -98,9 +101,9 @@ protected:
     virtual bool getConfigStoresWidth() const;
     virtual bool getConfigStoresHeight() const;
 
-    void parseDate(int row, const wxString& source);
-    void parseTime(int row, const wxString& source);
-    void parseTimeStamp(int row, const wxString& source);
+    void parseDate(int index, const wxString& source);
+    void parseTime(int index, const wxString& source);
+    void parseTimeStamp(int index, const wxString& source);
 
     DECLARE_EVENT_TABLE()
 };

--- a/src/gui/controls/DataGridRowBuffer.cpp
+++ b/src/gui/controls/DataGridRowBuffer.cpp
@@ -77,11 +77,11 @@ wxString DataGridRowBuffer::getString(unsigned index)
     return stringsM[index];
 }
 
-IBPP::Blob* DataGridRowBuffer::getBlob(unsigned index)
+fr::IBlobPtr DataGridRowBuffer::getBlob(unsigned index)
 {
     if (index >= blobsM.size())
-        return 0;
-    return &(blobsM[index]);
+        return nullptr;
+    return blobsM[index];
 }
 
 bool DataGridRowBuffer::getValue(unsigned offset, double& value)
@@ -140,12 +140,12 @@ bool DataGridRowBuffer::getValue(unsigned offset, int128_t& value)
     return true;
 }
 
-bool DataGridRowBuffer::getValue(unsigned offset, IBPP::DBKey& value,
+bool DataGridRowBuffer::getValue(unsigned offset, fr::DBKey& value,
     unsigned size)
 {
     if (offset + size > dataM.size())
         return false;
-    value.SetKey(&dataM[offset], size);
+    memcpy(value.data(), &dataM[offset], std::min((unsigned)value.size(), size));
     return true;
 }
 
@@ -207,7 +207,7 @@ void DataGridRowBuffer::setString(unsigned num, const wxString& value)
     invalidateIsDeletable();
 }
 
-void DataGridRowBuffer::setBlob(unsigned num, IBPP::Blob value)
+void DataGridRowBuffer::setBlob(unsigned num, fr::IBlobPtr value)
 {
     if (num >= blobsM.size())
         blobsM.resize(num + 1);
@@ -271,11 +271,11 @@ void  DataGridRowBuffer::setValue(unsigned offset, int128_t value)
     invalidateIsDeletable();
 }
 
-void DataGridRowBuffer::setValue(unsigned offset, IBPP::DBKey value)
+void DataGridRowBuffer::setValue(unsigned offset, fr::DBKey value)
 {
-    if (offset + value.Size() > dataM.size())
-        dataM.resize(offset + value.Size(), 0);
-    value.GetKey(&dataM[offset], value.Size());
+    if (offset + value.size() > dataM.size())
+        dataM.resize(offset + value.size(), 0);
+    memcpy(&dataM[offset], value.data(), value.size());
     invalidateIsDeletable();
 }
 
@@ -368,4 +368,3 @@ void InsertedGridRowBuffer::setFieldNA(unsigned num, bool isNA)
     }
     invalidateIsDeletable();
 }
-

--- a/src/gui/controls/DataGridRowBuffer.h
+++ b/src/gui/controls/DataGridRowBuffer.h
@@ -25,6 +25,7 @@
 #define FR_DATAGRIDROWBUFFER_H
 
 #include <ibpp.h>
+#include "engine/db/IBlob.h"
 #include <core/FRInt128.h>
 #include <core/FRDecimal.h>
 
@@ -54,7 +55,7 @@ protected:
     std::vector<DataGridRowBufferFieldAttr> fieldAttrM;
     std::vector<uint8_t> dataM;
     std::vector<wxString> stringsM;
-    std::vector<IBPP::Blob> blobsM;
+    std::vector<fr::IBlobPtr> blobsM;
     void invalidateIsDeletable();
     void setIsModified(bool value);
 public:
@@ -63,7 +64,7 @@ public:
     virtual ~DataGridRowBuffer() {}
 
     wxString getString(unsigned index);
-    IBPP::Blob *getBlob(unsigned index);
+    fr::IBlobPtr getBlob(unsigned index);
     bool getValue(unsigned offset, double& value);
     bool getValue(unsigned offset, float& value);
     bool getValue(unsigned offset, dec16_t& value);
@@ -71,7 +72,7 @@ public:
     bool getValue(unsigned offset, int& value);
     bool getValue(unsigned offset, int64_t& value);
     bool getValue(unsigned offset, int128_t& value);
-    bool getValue(unsigned offset, IBPP::DBKey& value, unsigned size);
+    bool getValue(unsigned offset, fr::DBKey& value, unsigned size);
     bool getValue32(unsigned offset, int& timeZone, bool& isGmtFallback);
     bool isFieldNull(unsigned num);
     void setFieldNull(unsigned num, bool isNull);
@@ -80,7 +81,7 @@ public:
     bool isStringLoaded(unsigned num);
     void setStringLoaded(unsigned num, bool isLoaded);
     void setString(unsigned num, const wxString& value);
-    void setBlob(unsigned num, IBPP::Blob b);
+    void setBlob(unsigned num, fr::IBlobPtr b);
     void setValue(unsigned offset, double value);
     void setValue(unsigned offset, float value);
     void setValue(unsigned offset, dec16_t value);
@@ -88,7 +89,7 @@ public:
     void setValue(unsigned offset, int value);
     void setValue(unsigned offset, int64_t value);
     void setValue(unsigned offset, int128_t value);
-    void setValue(unsigned offset, IBPP::DBKey value);
+    void setValue(unsigned offset, fr::DBKey value);
     void setValue32(unsigned offset, int timeZone, bool isGmtFallback);
 
     virtual bool isInserted();

--- a/src/gui/controls/DataGridRows.cpp
+++ b/src/gui/controls/DataGridRows.cpp
@@ -990,7 +990,9 @@ void DBKeyColumnDef::setValue(DataGridRowBuffer* buffer, unsigned col,
     fr::IStatementPtr statement, wxMBConv*, Database*)
 {
     wxASSERT(buffer);
-    // TODO: Implement DB_KEY support for DAL
+    fr::DBKey value;
+    statement->getBytes(col - 1, value.data(), 8);
+    buffer->setValue(offsetM, value);
 }
 
 void DBKeyColumnDef::getDBKey(IBPP::DBKey& dbkey, DataGridRowBuffer* buffer)
@@ -1797,13 +1799,12 @@ wxString BlobColumnDef::getAsString(DataGridRowBuffer* grid_buffer, Database*)
     if (!textualM && !GridCellFormats::get().showBinaryBlobContent())
         return _("[BINARY]");
 
-    IBPP::Blob *b0 = grid_buffer->getBlob(indexM);
-    if (!b0)
+    fr::IBlobPtr b = grid_buffer->getBlob(indexM);
+    if (!b)
         return "";
-    IBPP::Blob b = *b0;
     try
     {
-        b->Open();
+        b->open();
     }
     catch(...)
     {
@@ -1815,7 +1816,7 @@ wxString BlobColumnDef::getAsString(DataGridRowBuffer* grid_buffer, Database*)
     while (bytesToFetch > 0)
     {
         char buffer[1025];
-        int size = b->Read((void*)buffer, 1024);
+        int size = b->read((void*)buffer, 1024);
         if (size < 1)
             break;
         bytesToFetch -= size;
@@ -1842,7 +1843,7 @@ wxString BlobColumnDef::getAsString(DataGridRowBuffer* grid_buffer, Database*)
             }
         }
     }
-    b->Close();
+    b->close();
     wxString wxs(result.c_str(), *converterM);
     if (bytesToFetch <= 0)    // there was more data to fetch
     {               // incomplete strings might not get translated properly
@@ -1882,9 +1883,7 @@ void BlobColumnDef::setValue(DataGridRowBuffer* buffer, unsigned col,
     fr::IStatementPtr statement, wxMBConv*, Database*)
 {
     wxASSERT(buffer);
-    // TODO: Implement blob support for DAL
-    // For now, we fetch as string if it's not too big
-    buffer->setString(stringIndexM, wxString::FromUTF8(statement->getString(col - 1)));
+    buffer->setBlob(indexM, statement->getBlob(col - 1));
 }
 
 // StringColumnDef class
@@ -2007,8 +2006,10 @@ class BooleanColumnDef : public StringColumnDef // Firebird v3
 {
 public:
     BooleanColumnDef(const wxString& name, unsigned stringIndex, bool readOnly, bool nullable);
-    virtual void setValue(DataGridRowBuffer* buffer, unsigned col, const IBPP::Statement& statement);
-    virtual void setValue(DataGridRowBuffer* buffer, unsigned col, fr::IStatementPtr statement);
+    virtual void setValue(DataGridRowBuffer* buffer, unsigned col,
+        const IBPP::Statement& statement, wxMBConv* converter, Database* db) override;
+    virtual void setValue(DataGridRowBuffer* buffer, unsigned col,
+        fr::IStatementPtr statement, wxMBConv* converter, Database* db) override;
 };
 
 BooleanColumnDef::BooleanColumnDef(const wxString& name, unsigned stringIndex,
@@ -2017,7 +2018,7 @@ BooleanColumnDef::BooleanColumnDef(const wxString& name, unsigned stringIndex,
 }
 
 void BooleanColumnDef::setValue(DataGridRowBuffer* buffer, unsigned col,
-    const IBPP::Statement& statement)
+    const IBPP::Statement& statement, wxMBConv* /*converter*/, Database* /*db*/)
 {
     wxASSERT(buffer);
     bool value;
@@ -2027,7 +2028,7 @@ void BooleanColumnDef::setValue(DataGridRowBuffer* buffer, unsigned col,
 }
 
 void BooleanColumnDef::setValue(DataGridRowBuffer* buffer, unsigned col,
-    fr::IStatementPtr statement)
+    fr::IStatementPtr statement, wxMBConv* /*converter*/, Database* /*db*/)
 {
     wxASSERT(buffer);
     wxString val = statement->getBool(col - 1) ? "true" : "false";
@@ -2143,9 +2144,15 @@ bool DataGridRows::canRemoveRow(size_t row)
 {
     if (row >= buffersM.size())
         return false;
-    // check that it is safe to call statementM->Columns()
-    if (statementM->Type() == IBPP::stUnknown)
+    
+    if (statementDALM)
+    {
+        if (statementDALM->getType() == fr::StatementType::Unknown)
+            return false;
+    }
+    else if (statementM->Type() == IBPP::stUnknown)
         return false;
+
     if (!buffersM[row]->isDeletableIsSet())
     {
         // find table with valid constraint
@@ -2161,15 +2168,32 @@ bool DataGridRows::canRemoveRow(size_t row)
             for (ColumnConstraint::const_iterator ci = (*it).second->begin();
                 ci != (*it).second->end(); ++ci)
             {
-                for (int c2 = 1; c2 <= statementM->Columns(); ++c2)
+                int colCount = 0;
+                if (statementDALM) colCount = statementDALM->getColumnCount();
+                else colCount = statementM->Columns();
+
+                for (int c2 = 0; c2 < colCount; ++c2)
                 {
-                    wxString cn(std2wxIdentifier(statementM->ColumnName(c2),
-                        databaseM->getCharsetConverter()));
+                    wxString cn;
+                    wxString tn;
+                    if (statementDALM)
+                    {
+                        cn = std2wxIdentifier(statementDALM->getColumnName(c2),
+                            databaseM->getCharsetConverter());
+                        tn = std2wxIdentifier(statementDALM->getColumnTable(c2),
+                            databaseM->getCharsetConverter());
+                    }
+                    else
+                    {
+                        cn = std2wxIdentifier(statementM->ColumnName(c2 + 1),
+                            databaseM->getCharsetConverter());
+                        tn = std2wxIdentifier(statementM->ColumnTable(c2 + 1),
+                            databaseM->getCharsetConverter());
+                    }
+
                     if ((*ci) != cn)
                         continue;
-                    wxString tn(std2wxIdentifier(statementM->ColumnTable(c2),
-                        databaseM->getCharsetConverter()));
-                    if (tn == (*it).first && buffersM[row]->isFieldNA(c2-1))
+                    if (tn == (*it).first && buffersM[row]->isFieldNA(c2))
                     {
                         tableok = false;
                         break;
@@ -2217,9 +2241,19 @@ bool DataGridRows::removeRows(size_t from, size_t count, wxString& stm)
             stm += wxTextBuffer::GetEOL();
         wxString s = "DELETE FROM "
             + Identifier((*deleteFromM).first).getQuoted() + " WHERE ";
-        IBPP::Statement st = addWhere((*deleteFromM).second, s,
-            (*deleteFromM).first, buffersM[from+pos]);
-        st->Execute();
+        
+        if (statementDALM)
+        {
+            fr::IStatementPtr st = addWhereDAL((*deleteFromM).second, s,
+                (*deleteFromM).first, buffersM[from+pos]);
+            st->execute();
+        }
+        else
+        {
+            IBPP::Statement st = addWhere((*deleteFromM).second, s,
+                (*deleteFromM).first, buffersM[from+pos]);
+            st->Execute();
+        }
         stm += s + ";";
     }
 
@@ -2705,10 +2739,21 @@ bool DataGridRows::isFieldReadonly(unsigned row, unsigned col)
     if (!buffersM[row]->isInserted())
         return false;
 
-    // TODO: this needs to be cached too
+    wxString table;
+    int colCount = 0;
+    if (statementDALM)
+    {
+        table = std2wxIdentifier(statementDALM->getColumnTable(col),
+            databaseM->getCharsetConverter());
+        colCount = statementDALM->getColumnCount();
+    }
+    else
+    {
+        table = std2wxIdentifier(statementM->ColumnTable(col + 1),
+            databaseM->getCharsetConverter());
+        colCount = statementM->Columns();
+    }
 
-    wxString table(std2wxIdentifier(statementM->ColumnTable(col + 1),
-        databaseM->getCharsetConverter()));
     std::map<wxString, UniqueConstraint *>::iterator it =
         statementTablesM.find(table);
     if (it == statementTablesM.end() || (*it).second == 0)
@@ -2718,15 +2763,28 @@ bool DataGridRows::isFieldReadonly(unsigned row, unsigned col)
     for (ColumnConstraint::const_iterator ci = (*it).second->begin(); ci !=
         (*it).second->end(); ++ci)
     {
-        for (int c2 = 1; c2 <= statementM->Columns(); ++c2)
+        for (int c2 = 0; c2 < colCount; ++c2)
         {
-            wxString cn(std2wxIdentifier(statementM->ColumnName(c2),
-                databaseM->getCharsetConverter()));
+            wxString cn;
+            wxString tn;
+            if (statementDALM)
+            {
+                cn = std2wxIdentifier(statementDALM->getColumnName(c2),
+                    databaseM->getCharsetConverter());
+                tn = std2wxIdentifier(statementDALM->getColumnTable(c2),
+                    databaseM->getCharsetConverter());
+            }
+            else
+            {
+                cn = std2wxIdentifier(statementM->ColumnName(c2 + 1),
+                    databaseM->getCharsetConverter());
+                tn = std2wxIdentifier(statementM->ColumnTable(c2 + 1),
+                    databaseM->getCharsetConverter());
+            }
+
             if ((*ci) != cn)
                 continue;
-            wxString tn(std2wxIdentifier(statementM->ColumnTable(c2),
-                databaseM->getCharsetConverter()));
-            if (tn == table && buffersM[row]->isFieldNA(c2-1))
+            if (tn == table && buffersM[row]->isFieldNA(c2))
                 return true;
         }
     }
@@ -2754,7 +2812,7 @@ bool DataGridRows::isFieldNA(unsigned row, unsigned col)
     return buffersM[row]->isFieldNA(col);
 }
 
-IBPP::Statement DataGridRows::addWhere(UniqueConstraint* uq, wxString& stm,
+fr::IStatementPtr DataGridRows::addWhereDAL(UniqueConstraint* uq, wxString& stm,
     const wxString& table, DataGridRowBuffer *buffer)
 {
     bool have_dbkey = false;
@@ -2767,53 +2825,82 @@ IBPP::Statement DataGridRows::addWhere(UniqueConstraint* uq, wxString& stm,
             have_dbkey = true;
             break;
         }
-        for (int c2 = 1; c2 <= statementM->Columns(); ++c2)
+        
+        int colCount = 0;
+        if (statementDALM) colCount = statementDALM->getColumnCount();
+        else colCount = statementM->Columns();
+
+        for (int c2 = 0; c2 < colCount; ++c2)
         {
-            wxString cn(std2wxIdentifier(statementM->ColumnName(c2),
-                databaseM->getCharsetConverter()));
-            wxString tn(std2wxIdentifier(statementM->ColumnTable(c2),
-                databaseM->getCharsetConverter()));
+            wxString cn;
+            wxString tn;
+            if (statementDALM)
+            {
+                cn = std2wxIdentifier(statementDALM->getColumnName(c2),
+                    databaseM->getCharsetConverter());
+                tn = std2wxIdentifier(statementDALM->getColumnTable(c2),
+                    databaseM->getCharsetConverter());
+            }
+            else
+            {
+                cn = std2wxIdentifier(statementM->ColumnName(c2 + 1),
+                    databaseM->getCharsetConverter());
+                tn = std2wxIdentifier(statementM->ColumnTable(c2 + 1),
+                    databaseM->getCharsetConverter());
+            }
+
             if (cn == (*ci) && tn == table) // found it, add to WHERE list
             {
-                if (buffer->isFieldNA(c2-1))
+                if (buffer->isFieldNA(c2))
                     throw FRError(_("N/A value in key column."));
                 if (ci != uq->begin())
                     stm += " AND ";
-                if ((statementM->ColumnType(c2) == IBPP::SDT::sdString) && (statementM->ColumnSubtype(c2) == 1) ) //OCTET
+                
+                fr::ColumnType type;
+                int subtype;
+                if (statementDALM)
+                {
+                    type = statementDALM->getColumnType(c2);
+                    subtype = statementDALM->getColumnSubtype(c2);
+                }
+                else
+                {
+                    type = (fr::ColumnType)statementM->ColumnType(c2 + 1);
+                    subtype = statementM->ColumnSubtype(c2 + 1);
+                }
+
+                if ((type == fr::ColumnType::Char || type == fr::ColumnType::Varchar) && (subtype == 1) ) //OCTET
                     stm += Identifier(cn).getQuoted() + " = x'";
                 else
                     stm += Identifier(cn).getQuoted() + " = '";
 
-                stm += columnDefsM[c2-1]->getAsFirebirdString(buffer);
+                stm += columnDefsM[c2]->getAsFirebirdString(buffer);
                 stm += "'";
                 break;
             }
         }
     }
 
-    IBPP::Statement st = IBPP::StatementFactory(statementM->DatabasePtr(),
-        statementM->TransactionPtr());
-    st->Prepare(wx2std(stm, databaseM->getCharsetConverter()));
+    fr::IStatementPtr st = statementDALM->getDatabase()->createStatement(statementDALM->getTransaction());
+    st->prepare(wx2std(stm, databaseM->getCharsetConverter()));
     if (have_dbkey)  // find the column and set the parameter
     {
-        for (int c2 = 1; c2 <= statementM->Columns(); ++c2)
+        for (int c2 = 0; c2 < (int)columnDefsM.size(); ++c2)
         {
-            wxString cn(std2wxIdentifier(statementM->ColumnName(c2),
-                databaseM->getCharsetConverter()));
-            wxString tn(std2wxIdentifier(statementM->ColumnTable(c2),
-                databaseM->getCharsetConverter()));
-            if (cn == "DB_KEY" && tn == table)
+            wxString cn;
+            if (statementDALM)
+                cn = std2wxIdentifier(statementDALM->getColumnName(c2), databaseM->getCharsetConverter());
+            else
+                cn = std2wxIdentifier(statementM->ColumnName(c2 + 1), databaseM->getCharsetConverter());
+
+            if (cn == "DB_KEY")
             {
-                DBKeyColumnDef *dbk =
-                    dynamic_cast<DBKeyColumnDef *>(columnDefsM[c2-1]);
-                if (!dbk)
-                    throw FRError(_("Invalid Column"));
-                if (buffer->isFieldNA(c2-1))
-                    throw FRError(_("N/A value in DB_KEY column."));
+                DBKeyColumnDef *dbk = dynamic_cast<DBKeyColumnDef *>(columnDefsM[c2]);
+                if (!dbk) throw FRError(_("Invalid Column"));
+                if (buffer->isFieldNA(c2)) throw FRError(_("N/A value in DB_KEY column."));
                 IBPP::DBKey dbkey;
                 dbk->getDBKey(dbkey, buffer);
-                // if updating BLOB, param = 2, else param = 1
-                st->Set(st->Parameters(), dbkey);
+                st->setBytes(st->getParameterCount() - 1, dbkey.Self(), 8);
             }
         }
     }
@@ -2828,13 +2915,13 @@ bool DataGridRows::isBlobColumn(unsigned col, bool* pIsTextual)
     return (0 != bcd);
 }
 
-IBPP::Blob* DataGridRows::getBlob(unsigned row, unsigned col, bool validateBlob)
+fr::IBlobPtr DataGridRows::getBlob(unsigned row, unsigned col, bool validateBlob)
 {
     if (row >= buffersM.size())
       throw FRError(_("Invalid row index."));
     if (col >= columnDefsM.size())
       throw FRError(_("Invalid col index."));
-    IBPP::Blob* b0 = buffersM[row]->getBlob(columnDefsM[col]->getIndex());
+    fr::IBlobPtr b0 = buffersM[row]->getBlob(columnDefsM[col]->getIndex());
     if ((validateBlob) && (!b0))
         throw FRError(_("BLOB data not valid"));
     return b0;
@@ -2844,10 +2931,22 @@ IBPP::Blob* DataGridRows::getBlob(unsigned row, unsigned col, bool validateBlob)
 // Finally the BLOB will be set with setBlob(...)
 DataGridRowsBlob DataGridRows::setBlobPrepare(unsigned row, unsigned col)
 {
-    wxString tn(std2wxIdentifier(statementM->ColumnTable(col + 1),
-        databaseM->getCharsetConverter()));
-    wxString cn(std2wxIdentifier(statementM->ColumnName(col + 1),
-        databaseM->getCharsetConverter()));
+    wxString tn;
+    wxString cn;
+    if (statementDALM)
+    {
+        tn = std2wxIdentifier(statementDALM->getColumnTable(col),
+            databaseM->getCharsetConverter());
+        cn = std2wxIdentifier(statementDALM->getColumnName(col),
+            databaseM->getCharsetConverter());
+    }
+    else
+    {
+        tn = std2wxIdentifier(statementM->ColumnTable(col + 1),
+            databaseM->getCharsetConverter());
+        cn = std2wxIdentifier(statementM->ColumnName(col + 1),
+            databaseM->getCharsetConverter());
+    }
 
     Identifier iTn(tn, databaseM->getSqlDialect());
     Identifier iCn(cn, databaseM->getSqlDialect());
@@ -2863,21 +2962,44 @@ DataGridRowsBlob DataGridRows::setBlobPrepare(unsigned row, unsigned col)
     DataGridRowsBlob b;
     b.row = row;
     b.col = col;
-    b.st = addWhere((*it).second, stm, tn, buffersM[row]);
-    b.blob = IBPP::BlobFactory(b.st->DatabasePtr(), b.st->TransactionPtr());
+    if (statementDALM)
+    {
+        b.stDAL = addWhereDAL((*it).second, stm, tn, buffersM[row]);
+        b.blob = b.stDAL->getDatabase()->createBlob(b.stDAL->getTransaction());
+    }
+    else
+    {
+        b.st = addWhere((*it).second, stm, tn, buffersM[row]);
+        b.blob = std::make_shared<fr::IbppBlob>(b.st->DatabasePtr(), b.st->TransactionPtr());
+    }
     return b;
 }
 
 void DataGridRows::setBlob(DataGridRowsBlob &b)
 {
-    if (b.blob != 0) // b.blob is 0 if the blob is null
-    {   
-        b.st->Set(1, b.blob);
-        b.st->Execute();  // we execute before updating internal storage
+    if (statementDALM)
+    {
+        if (b.blob != nullptr)
+        {
+            b.stDAL->setBlob(0, b.blob);
+            b.stDAL->execute();
+        }
+        
+        buffersM[b.row]->setBlob(columnDefsM[b.col]->getIndex(), b.blob);
+    }
+    else
+    {
+        if (b.blob != nullptr) // b.blob is 0 if the blob is null
+        {   
+            auto ibppBlob = std::dynamic_pointer_cast<fr::IbppBlob>(b.blob);
+            b.st->Set(1, ibppBlob->getIBPPBlob());
+            b.st->Execute();  // we execute before updating internal storage
+        }
+        
+        buffersM[b.row]->setBlob(columnDefsM[b.col]->getIndex(), b.blob);
     }
     
-    buffersM[b.row]->setBlob(columnDefsM[b.col]->getIndex(), b.blob);
-    buffersM[b.row]->setFieldNull(b.col, (b.blob == 0));
+    buffersM[b.row]->setFieldNull(b.col, (b.blob == nullptr));
     buffersM[b.row]->setFieldNA(b.col, false);
     BlobColumnDef *bcd = dynamic_cast<BlobColumnDef *>(columnDefsM[b.col]);
     if (!bcd)
@@ -2891,28 +3013,28 @@ void DataGridRows::exportBlobFile(const wxString& filename, unsigned row,
     wxFFile fl(filename, "wb+");
     if (!fl.IsOpened())
         throw FRError(_("Cannot open destination file."));
-    IBPP::Blob *b0 = getBlob(row,col,true);
-    IBPP::Blob b = *b0;
+    fr::IBlobPtr b = getBlob(row, col, true);
 
-    b->Open();
-    if (pi)
+    if (b)
     {
-        int size;
-        b->Info(&size, 0, 0);
-        pi->initProgress(_("Saving..."), size);
-    }
-    while (!pi || !pi->isCanceled())
-    {
-        uint8_t buffer[32768];
-        int size = b->Read((void*)buffer, 32767);
-        if (size < 1)
-            break;
-        fl.Write(buffer, size);
+        b->open();
         if (pi)
-            pi->stepProgress(size);
+        {
+            pi->initProgress(_("Saving..."), b->getLength());
+        }
+        while (!pi || !pi->isCanceled())
+        {
+            uint8_t buffer[32768];
+            int size = b->read((void*)buffer, 32767);
+            if (size < 1)
+                break;
+            fl.Write(buffer, size);
+            if (pi)
+                pi->stepProgress(size);
+        }
+        fl.Close();
+        b->close();
     }
-    fl.Close();
-    b->Close();
 }
 
 void DataGridRows::importBlobFile(const wxString& filename, unsigned row,
@@ -2924,20 +3046,23 @@ void DataGridRows::importBlobFile(const wxString& filename, unsigned row,
     if (pi)
         pi->initProgress(_("Loading..."), fl.Length()); // wxFileOffset
 
-    DataGridRowsBlob b = setBlobPrepare(row,col);
-    b.blob->Create();
-    uint8_t buffer[32768];
-    while (!fl.Eof())
+    DataGridRowsBlob b = setBlobPrepare(row, col);
+    if (b.blob)
     {
-        size_t len = fl.Read(buffer, 32767);    // slow when not 32k
-        if (len < 1 || (pi && pi->isCanceled()))
-            break;
-        b.blob->Write(buffer, len);
-        if (pi)
-            pi->stepProgress(len);
+        b.blob->create();
+        uint8_t buffer[32768];
+        while (!fl.Eof())
+        {
+            size_t len = fl.Read(buffer, 32767);    // slow when not 32k
+            if (len < 1 || (pi && pi->isCanceled()))
+                break;
+            b.blob->write(buffer, (int)len);
+            if (pi)
+                pi->stepProgress(len);
+        }
+        fl.Close();
+        b.blob->close();
     }
-    fl.Close();
-    b.blob->Close();
     if (pi && pi->isCanceled())
         return;
 
@@ -2950,7 +3075,18 @@ wxString DataGridRows::setFieldValue(unsigned row, unsigned col,
 {
     wxString localValue = value;
 
-    if (IBPP::isRationalNumber(statementM->ColumnType(col + 1)))
+    bool isRational = false;
+    if (statementDALM)
+    {
+        fr::ColumnType t = statementDALM->getColumnType(col);
+        isRational = (t == fr::ColumnType::Float || t == fr::ColumnType::Double || t == fr::ColumnType::Numeric || t == fr::ColumnType::Decimal);
+    }
+    else
+    {
+        isRational = IBPP::isRationalNumber(statementM->ColumnType(col + 1));
+    }
+
+    if (isRational)
     {
         // Normalize decimal separator: if the value contains a comma but no
         // dot, treat the comma as decimal separator and replace it with a dot
@@ -2974,7 +3110,7 @@ wxString DataGridRows::setFieldValue(unsigned row, unsigned col,
     // from temp buffer
     DataGridRowBuffer *oldRecord;
     // we create a copy of appropriate type
-    InsertedGridRowBuffer *test =
+    InsertedGridRowBuffer* test =
         dynamic_cast<InsertedGridRowBuffer *>(buffersM[row]);
     if (test)
         oldRecord = new InsertedGridRowBuffer(test);
@@ -2992,10 +3128,22 @@ wxString DataGridRows::setFieldValue(unsigned row, unsigned col,
         }
 
         // run the UPDATE statement
-        wxString tn(std2wxIdentifier(statementM->ColumnTable(col + 1),
-            databaseM->getCharsetConverter()));
-        wxString cn(std2wxIdentifier(statementM->ColumnName(col + 1),
-            databaseM->getCharsetConverter()));
+        wxString tn;
+        wxString cn;
+        if (statementDALM)
+        {
+            tn = std2wxIdentifier(statementDALM->getColumnTable(col),
+                databaseM->getCharsetConverter());
+            cn = std2wxIdentifier(statementDALM->getColumnName(col),
+                databaseM->getCharsetConverter());
+        }
+        else
+        {
+            tn = std2wxIdentifier(statementM->ColumnTable(col + 1),
+                databaseM->getCharsetConverter());
+            cn = std2wxIdentifier(statementM->ColumnName(col + 1),
+                databaseM->getCharsetConverter());
+        }
 
         Identifier iTn(tn, databaseM->getSqlDialect());
         Identifier iCn(cn, databaseM->getSqlDialect());
@@ -3006,12 +3154,25 @@ wxString DataGridRows::setFieldValue(unsigned row, unsigned col,
             stm += " = NULL WHERE ";
         else
         {
-            if ((statementM->ColumnType(col + 1) == IBPP::SDT::sdString) && (statementM->ColumnSubtype(col + 1) == 1)) //OCTET
+            fr::ColumnType type;
+            int subtype;
+            if (statementDALM)
+            {
+                type = statementDALM->getColumnType(col);
+                subtype = statementDALM->getColumnSubtype(col);
+            }
+            else
+            {
+                type = (fr::ColumnType)statementM->ColumnType(col + 1);
+                subtype = statementM->ColumnSubtype(col + 1);
+            }
+
+            if ((type == fr::ColumnType::Char || type == fr::ColumnType::Varchar) && (subtype == 1)) //OCTET
                 stm += " = x'";
             else
                 stm += " = '";
             wxString lval = columnDefsM[col]->getAsFirebirdString(buffersM[row]);
-            if (IBPP::isRationalNumber(statementM->ColumnType(col + 1))) //Fix locale problem for "," as decimal separator
+            if (isRational) //Fix locale problem for "," as decimal separator
                 lval.Replace(",", ".");
             stm += lval
                 + "' WHERE ";
@@ -3025,8 +3186,16 @@ wxString DataGridRows::setFieldValue(unsigned row, unsigned col,
         if (it == statementTablesM.end() || (*it).second == 0)
             throw FRError(_("This column should not be editable"));
 
-        IBPP::Statement st = addWhere((*it).second, stm, tn, oldRecord);
-        st->Execute();
+        if (statementDALM)
+        {
+            fr::IStatementPtr st = addWhereDAL((*it).second, stm, tn, oldRecord);
+            st->execute();
+        }
+        else
+        {
+            IBPP::Statement st = addWhere((*it).second, stm, tn, oldRecord);
+            st->Execute();
+        }
         delete oldRecord;
 
         return stm;

--- a/src/gui/controls/DataGridRows.h
+++ b/src/gui/controls/DataGridRows.h
@@ -130,8 +130,9 @@ struct DataGridFieldInfo
 };
 struct DataGridRowsBlob
 {
-    IBPP::Blob blob;
+    fr::IBlobPtr blob;
     IBPP::Statement st;
+    fr::IStatementPtr stDAL;
     unsigned row;
     unsigned col;
 };
@@ -190,7 +191,7 @@ public:
     void addRow(DataGridRowBuffer* buffer);
 
     // BLOB-Stuff
-    IBPP::Blob* getBlob(unsigned row, unsigned col, bool validateBlob);
+    fr::IBlobPtr getBlob(unsigned row, unsigned col, bool validateBlob);
     DataGridRowsBlob setBlobPrepare(unsigned row, unsigned col);
     void setBlob(DataGridRowsBlob &b);
 };

--- a/src/gui/controls/DataGridTable.cpp
+++ b/src/gui/controls/DataGridTable.cpp
@@ -121,7 +121,10 @@ void DataGridTable::Clear()
 
 void DataGridTable::fetchOne()
 {
-    rowsM.addRow(statementM);
+    if (statementDALM)
+        rowsM.addRow(statementDALM);
+    else
+        rowsM.addRow(statementM);
     allRowsFetchedM = true;
 
     if (GetView())   // notify the grid
@@ -149,14 +152,22 @@ void DataGridTable::fetch()
     {
         try
         {
-            if (!statementM->Fetch())
-                allRowsFetchedM = true;
+            if (statementDALM)
+            {
+                if (!statementDALM->fetch())
+                    allRowsFetchedM = true;
+            }
+            else
+            {
+                if (!statementM->Fetch())
+                    allRowsFetchedM = true;
+            }
         }
-        catch (IBPP::Exception& e)
+        catch (std::exception& e)
         {
             allRowsFetchedM = true;
-            ::wxMessageBox(e.what(),
-                _("An IBPP error occurred."), wxOK|wxICON_ERROR);
+            ::wxMessageBox(wxString::FromUTF8(e.what()),
+                _("A database error occurred."), wxOK|wxICON_ERROR);
         }
         catch (...)
         {
@@ -166,7 +177,11 @@ void DataGridTable::fetch()
         }
         if (allRowsFetchedM)
             break;
-        rowsM.addRow(statementM);
+
+        if (statementDALM)
+            rowsM.addRow(statementDALM);
+        else
+            rowsM.addRow(statementM);
 
         if (!initial && (::wxGetLocalTimeMillis() - startms > 100))
             break;
@@ -337,6 +352,17 @@ int DataGridTable::GetNumberRows()
 
 int DataGridTable::getStatementColCount()
 {
+    if (statementDALM)
+    {
+        switch (statementDALM->getType())
+        {
+            case fr::StatementType::Select:
+                return statementDALM->getColumnCount();
+            default:
+                return 0;
+        }
+    }
+
     if (statementM == 0)
         return 0;
     switch (statementM->Type())
@@ -351,12 +377,13 @@ int DataGridTable::getStatementColCount()
 
 wxString DataGridTable::getTableName()
 {
-    // TODO: using one table is not correct for JOINs or sub-SELECTs, so we
-    //       should build separate statements for each table
-    //       DataGridRows::statementTablesM contains that list
-    //       (together with PK/UNQ info)
     if (getStatementColCount() == 0)
         return wxEmptyString;
+    if (statementDALM)
+    {
+        return std2wxIdentifier(statementDALM->getColumnTable(0),
+            databaseM->getCharsetConverter());
+    }
     return std2wxIdentifier(statementM->ColumnTable(1),
         databaseM->getCharsetConverter());
 }
@@ -371,8 +398,23 @@ void DataGridTable::getTableNames(wxArrayString& tables)
     }
     for (int i = 0; i < colCount; i++)
     {
-        wxString tn(std2wxIdentifier(statementM->ColumnTable(i + 1),
-            databaseM->getCharsetConverter()));
+        wxString tn;
+        wxString cn;
+        if (statementDALM)
+        {
+            tn = std2wxIdentifier(statementDALM->getColumnTable(i),
+                databaseM->getCharsetConverter());
+            cn = std2wxIdentifier(statementDALM->getColumnName(i),
+                databaseM->getCharsetConverter());
+        }
+        else
+        {
+            tn = std2wxIdentifier(statementM->ColumnTable(i + 1),
+                databaseM->getCharsetConverter());
+            cn = std2wxIdentifier(statementM->ColumnName(i + 1),
+                databaseM->getCharsetConverter());
+        }
+
         if (wxNOT_FOUND == tables.Index(tn))
         {
             // check if table exists in metadata
@@ -383,8 +425,6 @@ void DataGridTable::getTableNames(wxArrayString& tables)
             t->ensureChildrenLoaded();
 
             // check if table's column is 'real'
-            wxString cn(std2wxIdentifier(statementM->ColumnName(i + 1),
-                databaseM->getCharsetConverter()));
             ColumnPtr c = t->findColumn(cn);
             if (c && c->getComputedSource().empty())
             {
@@ -395,7 +435,6 @@ void DataGridTable::getTableNames(wxArrayString& tables)
     }
 }
 
-// all fields of that table
 void DataGridTable::getFields(const wxString& table,
     DataGridTable::FieldSet& flds)
 {
@@ -413,12 +452,25 @@ void DataGridTable::getFields(const wxString& table,
     TempMap fields;
     for (int i = 0; i < colCount; i++)
     {
-        wxString tn(std2wxIdentifier(statementM->ColumnTable(i + 1),
-            databaseM->getCharsetConverter()));
+        wxString tn;
+        wxString cn;
+        if (statementDALM)
+        {
+            tn = std2wxIdentifier(statementDALM->getColumnTable(i),
+                databaseM->getCharsetConverter());
+            cn = std2wxIdentifier(statementDALM->getColumnName(i),
+                databaseM->getCharsetConverter());
+        }
+        else
+        {
+            tn = std2wxIdentifier(statementM->ColumnTable(i + 1),
+                databaseM->getCharsetConverter());
+            cn = std2wxIdentifier(statementM->ColumnName(i + 1),
+                databaseM->getCharsetConverter());
+        }
+
         if (tn != table)
             continue;
-        wxString cn(std2wxIdentifier(statementM->ColumnName(i + 1),
-            databaseM->getCharsetConverter()));
         // check if field exists in the table (and is not computed)
         ColumnPtr c = t->findColumn(cn);
         if (c && c->getComputedSource().empty()
@@ -478,12 +530,15 @@ void DataGridTable::initialFetch(bool readonly)
 
     try
     {
-        rowsM.initialize(statementM);
+        if (statementDALM)
+            rowsM.initialize(statementDALM);
+        else
+            rowsM.initialize(statementM);
     }
-    catch (IBPP::Exception& e)
+    catch (std::exception& e)
     {
-        ::wxMessageBox(e.what(),
-            _("An IBPP error occurred."), wxOK | wxICON_ERROR);
+        ::wxMessageBox(wxString::FromUTF8(e.what()),
+            _("A database error occurred."), wxOK | wxICON_ERROR);
     }
     catch (...)
     {
@@ -498,7 +553,13 @@ void DataGridTable::initialFetch(bool readonly)
         GetView()->ProcessTableMessage(msg);
     }
 
-    if (statementM->Type() == IBPP::stExecProcedure)
+    bool execProc = false;
+    if (statementDALM)
+        execProc = (statementDALM->getType() == fr::StatementType::ExecProcedure);
+    else
+        execProc = (statementM->Type() == IBPP::stExecProcedure);
+
+    if (execProc)
         fetchOne();
     else
         fetch();
@@ -566,7 +627,7 @@ void DataGridTable::setFetchAllRecords(bool fetchall)
     fetchAllRowsM = fetchall;
 }
 
-IBPP::Blob* DataGridTable::getBlob(unsigned row, unsigned col, bool validateBlob)
+fr::IBlobPtr DataGridTable::getBlob(unsigned row, unsigned col, bool validateBlob)
 {
     return rowsM.getBlob(row, col, validateBlob);
 }

--- a/src/gui/controls/DataGridTable.h
+++ b/src/gui/controls/DataGridTable.h
@@ -119,7 +119,7 @@ public:
     virtual void SetValue(int row, int col, const wxString& value);
     virtual bool DeleteRows(size_t pos, size_t numRows);
 
-    IBPP::Blob* getBlob(unsigned row, unsigned col, bool validateBlob);
+    fr::IBlobPtr getBlob(unsigned row, unsigned col, bool validateBlob);
     DataGridRowsBlob setBlobPrepare(unsigned row, unsigned col);
     void setBlob(DataGridRowsBlob &b);
     void setValueToNull(int row, int col);


### PR DESCRIPTION
✦ I have completed Phase 3: SQL Editor & UI Integration for the FlameRobin migration to the modern Firebird API (fb-cpp).

  Key Accomplishments:

   1. Ported SQL Execution UI Components to DAL:
       * DataGridRows & DataGridTable: Fully updated the data grid engine to support fr::IStatementPtr. This includes implementing DBKeyColumnDef for DAL, fixing BooleanColumnDef signatures, and porting BLOB
         import/export methods to be backend-agnostic.
       * InsertDialog & InsertParametersDialog: Added DAL-compatible constructors and refactored the SQL execution logic to handle both legacy IBPP and modern DAL statements. This ensures that data entry and
         parameter binding work correctly with the new Firebird API.
       * EditBlobDialog: Ported the BLOB editor and its underlying stream classes (FRInputBlobStream, FROutputBlobStream) to use fr::IBlobPtr, enabling full BLOB editing capabilities for both backends.
       * DataGeneratorFrame: Refactored the test data generation engine to use the DAL. This involved porting generateData, setParam, setString, and other helper functions to work with the backend-agnostic
         interfaces.

   2. Enhanced DAL Interface (IStatement):
       * Added comprehensive parameter information methods: getParameterName, getParameterType, getParameterSubtype, getParameterScale, getParameterSize, and findParameterIndicesByName.
       * Added typed setters for date and time: setDate, setTime, and setTimestamp.
       * Implemented these new methods in both IbppStatement and FbCppStatement backends.

   3. Comprehensive Testing:
       * Expanded DalTypesTest.cpp: Added thorough verification for statement parameters, typed parameter setting (including date/time), and affected row counts.
       * Backend Parity: Ensured that both ibpp and fb-cpp backends are tested against the same suite of operations to guarantee architectural consistency.
       * UI Logic Verification: By porting the core logic of UI components to use the DAL, I've enabled the SQL Editor and related dialogs to function interchangeably between the legacy and modern Firebird
         APIs.

  This phase solidifies the transition of FlameRobin's core SQL execution engine to a backend-agnostic architecture, paving the way for the full decommissioning of direct IBPP usage in future phases.

