### PR TITLE
Potential fix for code scanning alert no. 463: Multiplication result converted to larger type

### DIFF
--- a/src/sql/SqlFormatter.cpp
+++ b/src/sql/SqlFormatter.cpp
@@ -99,7 +99,7 @@ wxString SqlFormatter::format(const wxString& sql, int odsMajor, int odsMinor)
     auto indent = [&]() {
         if (startOfLine)
         {
-            formattedSql += wxString(L' ', indentSpaces * indentLevel);
+            formattedSql += wxString(L' ', static_cast<size_t>(indentSpaces) * static_cast<size_t>(indentLevel));
             startOfLine = false;
         }
     };


### PR DESCRIPTION
Potential fix for [https://github.com/mariuz/flamerobin/security/code-scanning/463](https://github.com/mariuz/flamerobin/security/code-scanning/463)

To fix this safely without changing intended behavior, ensure multiplication is done in a type wide enough for string length/count arithmetic (use `size_t`) **before** the multiply happens.

Best change in `src/sql/SqlFormatter.cpp` at the `indent` lambda:

- Replace `indentSpaces * indentLevel` with `static_cast<size_t>(indentSpaces) * static_cast<size_t>(indentLevel)`.

This preserves current logic, avoids intermediate `int` overflow, and matches what `wxString` count-based constructor expects.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
